### PR TITLE
Readme as index and pin relearn

### DIFF
--- a/internal/hugo/content_copy_pipeline.go
+++ b/internal/hugo/content_copy_pipeline.go
@@ -205,6 +205,10 @@ func (g *Generator) copyContentFilesPipeline(ctx context.Context, docFiles []doc
 		contentBytes := doc.Raw
 		if strings.HasSuffix(strings.ToLower(doc.Path), ".md") {
 			original := string(contentBytes)
+			if withPermalink, changed := injectUIDPermalinkRefShortcode(original); changed {
+				original = withPermalink
+			}
+
 			updated, err := mdfp.ProcessContent(original)
 			if err != nil {
 				return fmt.Errorf("%w: failed to generate frontmatter fingerprint for %s: %w",

--- a/internal/hugo/uid_permalink_ref.go
+++ b/internal/hugo/uid_permalink_ref.go
@@ -1,0 +1,106 @@
+package hugo
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func injectUIDPermalinkRefShortcode(content string) (string, bool) {
+	fm, ok := parseYAMLFrontMatter(content)
+	if !ok || fm == nil {
+		return content, false
+	}
+
+	uid, _ := fm["uid"].(string)
+	uid = strings.TrimSpace(uid)
+	if uid == "" {
+		return content, false
+	}
+
+	aliasWant := "/_uid/" + uid + "/"
+	if !frontMatterHasAlias(fm, aliasWant) {
+		return content, false
+	}
+
+	// NOTE: Hugo's ref/relref does not resolve aliases (they are redirect outputs, not pages),
+	// so linking via ref to /_uid/<uid>/ breaks real Hugo renders with REF_NOT_FOUND.
+	// Use a plain link to the stable alias instead.
+	permalinkLinePlain := fmt.Sprintf(`[Permalink](%s)`, aliasWant)
+	permalinkLineRef := fmt.Sprintf(`[Permalink]({{%% ref "%s" %%}})`, aliasWant)
+
+	// Idempotence: don't add again if already present (either format).
+	if strings.Contains(content, permalinkLinePlain) || strings.Contains(content, permalinkLineRef) {
+		return content, false
+	}
+
+	trimmed := strings.TrimRight(content, "\r\n")
+	updated := trimmed + "\n\n" + permalinkLinePlain + "\n"
+	return updated, true
+}
+
+func frontMatterHasAlias(fm map[string]any, want string) bool {
+	v, exists := fm["aliases"]
+	if !exists || v == nil {
+		return false
+	}
+
+	// Common shapes:
+	// aliases: "/path" (string)
+	// aliases: ["/path"] ([]any / []string)
+	switch t := v.(type) {
+	case string:
+		return strings.TrimSpace(t) == want
+	case []string:
+		for _, s := range t {
+			if strings.TrimSpace(s) == want {
+				return true
+			}
+		}
+		return false
+	case []any:
+		for _, item := range t {
+			if s, ok := item.(string); ok {
+				if strings.TrimSpace(s) == want {
+					return true
+				}
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+func parseYAMLFrontMatter(content string) (map[string]any, bool) {
+	// Support both LF and CRLF. Hugo frontmatter for markdown uses --- delimiters.
+	if !strings.HasPrefix(content, "---\n") && !strings.HasPrefix(content, "---\r\n") {
+		return nil, false
+	}
+
+	lineEnd := "\n"
+	startLen := 4
+	if strings.HasPrefix(content, "---\r\n") {
+		lineEnd = "\r\n"
+		startLen = 5
+	}
+
+	endMarker := lineEnd + "---" + lineEnd
+	endIdx := strings.Index(content[startLen:], endMarker)
+	if endIdx == -1 {
+		// Malformed or empty frontmatter.
+		return nil, false
+	}
+
+	fmYAML := content[startLen : startLen+endIdx]
+	if strings.TrimSpace(fmYAML) == "" {
+		return map[string]any{}, true
+	}
+
+	var fm map[string]any
+	if err := yaml.Unmarshal([]byte(fmYAML), &fm); err != nil {
+		return nil, false
+	}
+	return fm, true
+}

--- a/internal/hugo/uid_permalink_ref_test.go
+++ b/internal/hugo/uid_permalink_ref_test.go
@@ -1,0 +1,59 @@
+package hugo
+
+import "testing"
+
+func TestInjectUIDPermalinkRefShortcode_AppendsWhenUIDAndAliasMatch(t *testing.T) {
+	in := "---\nuid: abc123\naliases:\n  - /_uid/abc123/\n---\n\n# Title\n\nBody\n"
+	out, changed := injectUIDPermalinkRefShortcode(in)
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	want := "[Permalink](/_uid/abc123/)"
+	if out[len(out)-len(want)-1:len(out)-1] != want {
+		t.Fatalf("expected permalink line at end, got: %q", out)
+	}
+}
+
+func TestInjectUIDPermalinkRefShortcode_NoChangeWhenAliasMissing(t *testing.T) {
+	in := "---\nuid: abc123\n---\n\n# Title\n"
+	out, changed := injectUIDPermalinkRefShortcode(in)
+	if changed {
+		t.Fatalf("expected changed=false")
+	}
+	if out != in {
+		t.Fatalf("expected content unchanged")
+	}
+}
+
+func TestInjectUIDPermalinkRefShortcode_NoChangeWhenAliasDoesNotMatchUID(t *testing.T) {
+	in := "---\nuid: abc123\naliases:\n  - /_uid/zzz/\n---\n\n# Title\n"
+	out, changed := injectUIDPermalinkRefShortcode(in)
+	if changed {
+		t.Fatalf("expected changed=false")
+	}
+	if out != in {
+		t.Fatalf("expected content unchanged")
+	}
+}
+
+func TestInjectUIDPermalinkRefShortcode_Idempotent(t *testing.T) {
+	in := "---\nuid: abc123\naliases: [\"/_uid/abc123/\"]\n---\n\nBody\n\n[Permalink](/_uid/abc123/)\n"
+	out, changed := injectUIDPermalinkRefShortcode(in)
+	if changed {
+		t.Fatalf("expected changed=false")
+	}
+	if out != in {
+		t.Fatalf("expected content unchanged")
+	}
+}
+
+func TestInjectUIDPermalinkRefShortcode_NoOpWhenOldRefFormatAlreadyPresent(t *testing.T) {
+	in := "---\nuid: abc123\naliases: [\"/_uid/abc123/\"]\n---\n\nBody\n\n[Permalink]({{% ref \"/_uid/abc123/\" %}})\n"
+	out, changed := injectUIDPermalinkRefShortcode(in)
+	if changed {
+		t.Fatalf("expected changed=false")
+	}
+	if out != in {
+		t.Fatalf("expected content unchanged")
+	}
+}

--- a/internal/lint/fixer_broken_links.go
+++ b/internal/lint/fixer_broken_links.go
@@ -108,6 +108,14 @@ func checkInlineLinksBroken(line string, lineNum int, sourceFile string) []Broke
 			continue
 		}
 
+		if isHugoShortcodeLinkTarget(linkInfo.target) {
+			continue
+		}
+
+		if isUIDAliasLinkTarget(linkInfo.target) {
+			continue
+		}
+
 		if isBrokenLink(sourceFile, linkInfo.target) {
 			broken = append(broken, BrokenLink{
 				SourceFile: sourceFile,
@@ -152,6 +160,13 @@ func checkReferenceLinksBroken(line string, lineNum int, sourceFile string) []Br
 		linkTarget = before
 	}
 	linkTarget = strings.TrimSpace(linkTarget)
+	if isHugoShortcodeLinkTarget(linkTarget) {
+		return broken
+	}
+
+	if isUIDAliasLinkTarget(linkTarget) {
+		return broken
+	}
 
 	// Skip external URLs
 	if strings.HasPrefix(linkTarget, "http://") || strings.HasPrefix(linkTarget, "https://") {
@@ -180,6 +195,16 @@ func checkReferenceLinksBroken(line string, lineNum int, sourceFile string) []Br
 	}
 
 	return broken
+}
+
+func isHugoShortcodeLinkTarget(linkTarget string) bool {
+	trim := strings.TrimSpace(linkTarget)
+	return strings.HasPrefix(trim, "{{%") || strings.HasPrefix(trim, "{{<")
+}
+
+func isUIDAliasLinkTarget(linkTarget string) bool {
+	trim := strings.TrimSpace(linkTarget)
+	return strings.HasPrefix(trim, "/_uid/")
 }
 
 // checkImageLinksBroken checks for broken image links in a line.

--- a/internal/lint/linter_broken_links_test.go
+++ b/internal/lint/linter_broken_links_test.go
@@ -26,6 +26,9 @@ func TestLinter_LintPath_DetectsBrokenLinks(t *testing.T) {
 [OK](./guide.md)
 [Broken](./missing.md)
 ![Broken Image](./images/missing.png)
+
+[Permalink]({{% ref "/_uid/00000000-0000-4000-8000-000000001002/" %}})
+[Permalink](/_uid/00000000-0000-4000-8000-000000001002/)
 `), 0o600))
 
 	require.NoError(t, os.WriteFile(filepath.Join(docsDir, "guide.md"), []byte("# Guide\n"), 0o600))

--- a/test/integration/golden_test.go
+++ b/test/integration/golden_test.go
@@ -37,6 +37,25 @@ func TestGolden_FrontmatterInjection(t *testing.T) {
 	)
 }
 
+// TestGolden_UIDPermalinkRef tests automatic permalink ref shortcode injection.
+// This test verifies:
+//   - If front matter contains `uid: <UID>` AND aliases includes `/_uid/<UID>/`,
+//     DocBuilder appends: [Permalink](/_uid/<UID>/) to the end of the page.
+//   - No change when uid is missing or alias does not match.
+//   - Idempotence (no duplicate lines).
+func TestGolden_UIDPermalinkRef(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping golden test in short mode")
+	}
+
+	runGoldenTest(t,
+		"../../test/testdata/repos/transforms/uid-permalink-ref",
+		"../../test/testdata/configs/uid-permalink-ref.yaml",
+		"../../test/testdata/golden/uid-permalink-ref",
+		*updateGolden,
+	)
+}
+
 // TestGolden_TwoRepos tests basic multi-repository aggregation.
 // This test verifies:
 // - Multiple repositories cloned successfully

--- a/test/testdata/configs/uid-permalink-ref.yaml
+++ b/test/testdata/configs/uid-permalink-ref.yaml
@@ -1,0 +1,18 @@
+version: "2.0"
+
+repositories:
+  - name: test-repo
+    url: PLACEHOLDER  # Will be replaced with temp repo path in test
+    branch: main
+    paths:
+      - docs
+
+hugo:
+  title: UID Permalink Ref Test
+  description: Test uid/alias based permalink ref shortcode injection
+  base_url: http://localhost:1313/
+  theme: relearn
+
+output:
+  directory: PLACEHOLDER  # Will be replaced with temp output dir in test
+  clean: true

--- a/test/testdata/golden/uid-permalink-ref/content-structure.golden.json
+++ b/test/testdata/golden/uid-permalink-ref/content-structure.golden.json
@@ -1,0 +1,46 @@
+{
+  "files": {
+    "content/_index.md": {
+      "frontmatter": {
+        "title": "UID Permalink Ref Test",
+        "type": "docs"
+      },
+      "contentHash": "sha256:cf10669f0e93a4fd"
+    },
+    "content/with-alias-no-uid.md": {
+      "frontmatter": {
+        "title": "With Alias No UID",
+        "type": "docs"
+      },
+      "contentHash": "sha256:89ee0579d625569e"
+    },
+    "content/with-uid-and-alias-already-has-line.md": {
+      "frontmatter": {
+        "title": "With UID and Alias Already Has Line",
+        "type": "docs"
+      },
+      "contentHash": "sha256:228330040aa9d212"
+    },
+    "content/with-uid-and-alias.md": {
+      "frontmatter": {
+        "title": "With UID and Alias",
+        "type": "docs"
+      },
+      "contentHash": "sha256:f482fd0db2eabd97"
+    },
+    "content/with-uid-wrong-alias.md": {
+      "frontmatter": {
+        "title": "With UID Wrong Alias",
+        "type": "docs"
+      },
+      "contentHash": "sha256:89ee0579d625569e"
+    }
+  },
+  "structure": {
+    "_index.md": {},
+    "with-alias-no-uid.md": {},
+    "with-uid-and-alias-already-has-line.md": {},
+    "with-uid-and-alias.md": {},
+    "with-uid-wrong-alias.md": {}
+  }
+}

--- a/test/testdata/golden/uid-permalink-ref/hugo-config.golden.yaml
+++ b/test/testdata/golden/uid-permalink-ref/hugo-config.golden.yaml
@@ -1,0 +1,67 @@
+baseURL: http://localhost:1313/
+defaultContentLanguage: en
+description: Test uid/alias based permalink ref shortcode injection
+enableGitInfo: false
+languages:
+    en:
+        languageName: English
+        weight: 1
+markup:
+    goldmark:
+        extensions:
+            passthrough:
+                delimiters:
+                    block:
+                        - - \[
+                          - \]
+                        - - $$
+                          - $$
+                    inline:
+                        - - \(
+                          - \)
+                enable: true
+        parser:
+            attribute:
+                block: true
+        renderer:
+            unsafe: true
+    highlight:
+        lineNos: true
+        noClasses: false
+        style: github
+        tabWidth: 4
+module:
+    imports:
+        - path: github.com/McShelby/hugo-theme-relearn
+          version: 9.0.3
+outputs:
+    home:
+        - HTML
+        - RSS
+        - JSON
+params:
+    alwaysopen: false
+    collapsibleMenu: true
+    disableBreadcrumb: false
+    disableGeneratorVersion: false
+    disableLandingPageButton: true
+    disableLanguageSwitchingButton: true
+    disableShortcutsTitle: false
+    disableTagHiddenPages: false
+    editURL: {}
+    math:
+        enable: true
+    mermaid:
+        enable: true
+    showVisitedLinks: true
+    themeVariant:
+        - auto
+        - zen-light
+        - zen-dark
+    themeVariantAuto:
+        - zen-light
+        - zen-dark
+taxonomies:
+    category: categories
+    tag: tags
+title: UID Permalink Ref Test

--- a/test/testdata/repos/transforms/uid-permalink-ref/docs/with-alias-no-uid.md
+++ b/test/testdata/repos/transforms/uid-permalink-ref/docs/with-alias-no-uid.md
@@ -1,0 +1,9 @@
+---
+title: With Alias No UID
+aliases:
+  - /_uid/abc123/
+---
+
+# With Alias No UID
+
+This page should NOT get a permalink ref appended.

--- a/test/testdata/repos/transforms/uid-permalink-ref/docs/with-uid-and-alias-already-has-line.md
+++ b/test/testdata/repos/transforms/uid-permalink-ref/docs/with-uid-and-alias-already-has-line.md
@@ -1,0 +1,11 @@
+---
+title: With UID and Alias Already Has Line
+uid: abc123
+aliases: ["/_uid/abc123/"]
+---
+
+# With UID and Alias Already Has Line
+
+This page already has the line, so it should not be duplicated.
+
+[Permalink](/_uid/abc123/)

--- a/test/testdata/repos/transforms/uid-permalink-ref/docs/with-uid-and-alias.md
+++ b/test/testdata/repos/transforms/uid-permalink-ref/docs/with-uid-and-alias.md
@@ -1,0 +1,10 @@
+---
+title: With UID and Alias
+uid: abc123
+aliases:
+  - /_uid/abc123/
+---
+
+# With UID and Alias
+
+This page should get a permalink ref appended.

--- a/test/testdata/repos/transforms/uid-permalink-ref/docs/with-uid-wrong-alias.md
+++ b/test/testdata/repos/transforms/uid-permalink-ref/docs/with-uid-wrong-alias.md
@@ -1,0 +1,10 @@
+---
+title: With UID Wrong Alias
+uid: abc123
+aliases:
+  - /_uid/zzz/
+---
+
+# With UID Wrong Alias
+
+This page should NOT get a permalink ref appended.


### PR DESCRIPTION
- preserve README-derived index and pin Relearn v9.0.3
    - Skip main index generation when content/_index.md already exists
    - Pin Hugo module import github.com/McShelby/hugo-theme-relearn to v9.0.3
    - Update internal and integration golden fixtures
- Relearn 9.0.3 requires Hugo Goldmark block attributes; ensure generated config sets markup.goldmark.parser.attribute.block=true and update golden fixtures