### PR TITLE
PR: ADR-012 — Auto-heal links to moved/renamed files (merge `shaman-healer` → `fixing`)

### DIFF
--- a/docs/adr/adr-012-implementation-plan.md
+++ b/docs/adr/adr-012-implementation-plan.md
@@ -132,16 +132,18 @@ This is the key functional delta versus current link updates.
 
 ### 5) Git history detection (since last push)
 
-- [ ] Detect upstream tracking branch if present.
-- [ ] Extract rename mappings for commits “since last push” (HEAD vs upstream).
-- [ ] Provide bounded fallback when upstream is absent.
+- [x] Detect upstream tracking branch if present.
+- [x] Extract rename mappings for commits “since last push” (HEAD vs upstream).
+- [x] Provide bounded fallback when upstream is absent.
 - [ ] Tests:
-  - [ ] uses upstream range when available
-  - [ ] bounded fallback works without upstream
+  - [x] uses upstream range when available
+  - [x] bounded fallback works without upstream
 
 **Definition of Done**
 
 - Broken links can be healed even when the rename was already committed locally.
+
+**Completion**: 2026-01-23 — branch: `shaman-healer`
 
 ### 6) Ambiguity + safety
 
@@ -157,8 +159,8 @@ This is the key functional delta versus current link updates.
 
 ### 7) Verification gate
 
-- [x] `go test ./... -count=1`
-- [x] `golangci-lint run --fix` then `golangci-lint run`
+- [ ] `go test ./... -count=1`
+- [ ] `golangci-lint run --fix` then `golangci-lint run`
 
 ## Notes / Risks
 

--- a/docs/adr/adr-012-implementation-plan.md
+++ b/docs/adr/adr-012-implementation-plan.md
@@ -119,14 +119,16 @@ This is the key functional delta versus current link updates.
 
 ### 4) Healing strategy: focus on broken links
 
-- [ ] Use existing broken-link detection output as the primary worklist.
-- [ ] For each broken link, resolve the absolute target (existing `resolveRelativePath` behavior) and match against rename mappings.
-- [ ] Apply link updates via existing edit machinery (minimal diffs; no Markdown reformatting).
-- [ ] Ensure fingerprint refresh is triggered for updated files (consistent with current fixer behavior).
+- [x] Use existing broken-link detection output as the primary worklist.
+- [x] For each broken link, resolve the absolute target (existing `resolveRelativePath` behavior) and match against rename mappings.
+- [x] Apply link updates via existing edit machinery (minimal diffs; no Markdown reformatting).
+- [x] Ensure fingerprint refresh is triggered for updated files (consistent with current fixer behavior).
 
 **Definition of Done**
 
 - A new healing phase runs during `lint --fix` and produces `LinksUpdated` entries, without requiring the fixer to have performed the rename itself.
+
+**Completion**: 2026-01-23 — branch: `shaman-healer`
 
 ### 5) Git history detection (since last push)
 
@@ -155,8 +157,8 @@ This is the key functional delta versus current link updates.
 
 ### 7) Verification gate
 
-- [ ] `go test ./... -count=1`
-- [ ] `golangci-lint run --fix` then `golangci-lint run`
+- [x] `go test ./... -count=1`
+- [x] `golangci-lint run --fix` then `golangci-lint run`
 
 ## Notes / Risks
 

--- a/docs/adr/adr-012-implementation-plan.md
+++ b/docs/adr/adr-012-implementation-plan.md
@@ -4,7 +4,7 @@ aliases:
 categories:
   - architecture-decisions
 date: 2026-01-23T00:00:00Z
-fingerprint: 96840c5836e1074e3ec0b5506aeccc0ba24b75e1fc9ed68330e3253a6dd77875
+fingerprint: 1a4342592c6e4fc14af21742a13769445493e0cc36c536effaa1a8f99b0dbe46
 lastmod: "2026-01-23"
 tags:
   - linting

--- a/docs/adr/adr-012-implementation-plan.md
+++ b/docs/adr/adr-012-implementation-plan.md
@@ -57,57 +57,65 @@ If the final implementation deviates, update this plan and ADR-012 accordingly.
 
 ### 0) Baseline characterization (no behavior change)
 
-- [ ] Add tests that characterize existing rename + link update behavior:
-  - [ ] filename normalization rename (case/spaces) updates links correctly
-  - [ ] link updates preserve fragments (`#...`) and relative prefixes (`./`, `../`)
-  - [ ] link updates do not touch code blocks / inline code
+- [x] Add tests that characterize existing rename + link update behavior:
+  - [x] filename normalization rename (case/spaces) updates links correctly
+  - [x] link updates preserve fragments (`#...`) and relative prefixes (`./`, `../`)
+  - [x] link updates do not touch code blocks / inline code
 
 **Definition of Done**
 
 - Tests pass and clearly document current behavior and limitations.
 
+**Completion**: 2026-01-23 — commit: `41ba5d7`
+
 ### 1) Introduce rename mapping type + plumbing hooks
 
-- [ ] Add a small internal type (or reuse existing) that represents `oldAbs -> newAbs` mappings and can be fed into the link update path.
-- [ ] Add unit tests for:
-  - [ ] mapping normalization (absolute paths, docs-root scoping)
-  - [ ] de-duplication and deterministic ordering
+- [x] Add a small internal type (or reuse existing) that represents `oldAbs -> newAbs` mappings and can be fed into the link update path.
+- [x] Add unit tests for:
+  - [x] mapping normalization (absolute paths, docs-root scoping)
+  - [x] de-duplication and deterministic ordering
 
 **Definition of Done**
 
 - There is a single representation of renames used by both fixer-driven renames and Git-derived renames.
 
+**Completion**: 2026-01-23 — commit: `c664cd1`
+
 ### 2) Git rename detection (uncommitted)
 
 **Intent**: catch the common “pre-commit rename broke links” workflow.
 
-- [ ] Implement/introduce `GitRenameDetector` for uncommitted renames:
-  - [ ] staged renames
-  - [ ] unstaged renames
-- [ ] Ensure it is safe when not in a git repo: returns `(nil, nil)`.
-- [ ] Tests:
-  - [ ] returns mappings for a repo with a `git mv` rename
-  - [ ] ignores non-doc-root renames
+- [x] Implement/introduce `GitRenameDetector` for uncommitted renames:
+  - [x] staged renames
+  - [x] unstaged renames
+- [x] Ensure it is safe when not in a git repo: returns `(nil, nil)`.
+- [x] Tests:
+  - [x] returns mappings for a repo with a `git mv` rename
+  - [x] ignores non-doc-root renames
 
 **Definition of Done**
 
 - We can produce a reliable set of `(oldAbs, newAbs)` mappings for working tree/index.
 
+**Completion**: 2026-01-23 — commit: `ac7a996`
+
 ### 3) Correct link target rewriting for moved files
 
 This is the key functional delta versus current link updates.
 
-- [ ] Implement `computeUpdatedLinkTarget(sourceFile, originalTarget, oldAbs, newAbs)`.
-- [ ] Unit tests must cover:
-  - [ ] relative link targets (`../a/b.md`) moved across directories
-  - [ ] same-dir links remain minimal
-  - [ ] site-absolute links (`/docs/foo`) stay site-absolute and update correctly
-  - [ ] extension style preserved (`foo` stays `foo` if originally extensionless; `foo.md` stays `.md`)
-  - [ ] fragments preserved (`#section`)
+- [x] Implement `computeUpdatedLinkTarget(sourceFile, originalTarget, oldAbs, newAbs)`.
+- [x] Unit tests must cover:
+  - [x] relative link targets (`../a/b.md`) moved across directories
+  - [x] same-dir links remain minimal
+  - [x] site-absolute links (`/docs/foo`) stay site-absolute and update correctly
+  - [x] extension style preserved (`foo` stays `foo` if originally extensionless; `foo.md` stays `.md`)
+  - [x] fragments preserved (`#section`)
 
 **Definition of Done**
 
 - For moved targets, the updated destination resolves to `newAbs` when interpreted from `sourceFile`.
+
+**Completion**: 2026-01-23 — commit: `8c76205`
 
 ### 4) Healing strategy: focus on broken links
 

--- a/docs/adr/adr-012-implementation-plan.md
+++ b/docs/adr/adr-012-implementation-plan.md
@@ -135,7 +135,7 @@ This is the key functional delta versus current link updates.
 - [x] Detect upstream tracking branch if present.
 - [x] Extract rename mappings for commits “since last push” (HEAD vs upstream).
 - [x] Provide bounded fallback when upstream is absent.
-- [ ] Tests:
+- [x] Tests:
   - [x] uses upstream range when available
   - [x] bounded fallback works without upstream
 
@@ -147,20 +147,22 @@ This is the key functional delta versus current link updates.
 
 ### 6) Ambiguity + safety
 
-- [ ] Multiple-candidate handling:
-  - [ ] if a broken target maps to multiple plausible new targets, do not rewrite; emit a warning/result entry.
-- [ ] Scope enforcement:
-  - [ ] only heal within configured docs roots
-  - [ ] do not rewrite external links, UID alias links, or Hugo shortcodes
+- [x] Multiple-candidate handling:
+  - [x] if a broken target maps to multiple plausible new targets, do not rewrite; emit a warning/result entry.
+- [x] Scope enforcement:
+  - [x] only heal within configured docs roots
+  - [x] do not rewrite external links, UID alias links, or Hugo shortcodes
 
 **Definition of Done**
 
 - Healer never rewrites links to out-of-scope targets.
 
+**Completion**: 2026-01-23 — branch: `shaman-healer`
+
 ### 7) Verification gate
 
-- [ ] `go test ./... -count=1`
-- [ ] `golangci-lint run --fix` then `golangci-lint run`
+- [x] `go test ./... -count=1`
+- [x] `golangci-lint run --fix` then `golangci-lint run`
 
 ## Notes / Risks
 

--- a/docs/adr/adr-012-implementation-plan.md
+++ b/docs/adr/adr-012-implementation-plan.md
@@ -1,0 +1,156 @@
+---
+aliases:
+  - /_uid/f967d658-528f-4f12-a1d8-62c203356882/
+categories:
+  - architecture-decisions
+date: 2026-01-23T00:00:00Z
+fingerprint: 96840c5836e1074e3ec0b5506aeccc0ba24b75e1fc9ed68330e3253a6dd77875
+lastmod: "2026-01-23"
+tags:
+  - linting
+  - links
+  - file-system
+  - implementation-plan
+  - git
+uid: f967d658-528f-4f12-a1d8-62c203356882
+---
+# ADR-012 Implementation Plan: Autoheal links to files moved
+
+**Status**: Draft / Tracking  
+**Date**: 2026-01-23  
+**Decision Makers**: DocBuilder Core Team
+
+This document is the execution plan for [ADR-012: Autoheal links to files moved](adr-012-autoheal-links-to-moved-files.md).
+
+## Goal
+
+Extend `docbuilder lint --fix` to heal broken relative links caused by user-performed renames/moves (e.g., `git mv`) by detecting rename mappings from Git state/history and reusing the existing fixer link update machinery.
+
+## Non-goals
+
+- Proactively renaming files beyond existing filename normalization fixes.
+- Rewriting links outside configured documentation roots.
+- Reformatting Markdown or re-rendering content; edits must remain minimal-diff destination replacements.
+
+## Guardrails
+
+- Strict TDD: failing test first, then minimal implementation.
+- Prefer reuse of existing components:
+  - broken link detection (`detectBrokenLinks*`)
+  - link discovery (`findLinksInFile` / `findLinksToFile`) and edit application (`applyLinkUpdates`)
+  - fingerprint regeneration ordering (must remain last)
+- Keep changes scoped to `internal/lint` (plus `internal/git` reuse if/when needed).
+- Performance: healing should be proportional to broken links found (avoid scanning the whole repo for every rename).
+
+## Target API (concrete shape)
+
+This plan assumes the API sketch in the ADR is implemented in `internal/lint`:
+
+- `RenameSource`, `RenameMapping`
+- `GitRenameDetector` (uncommitted + history)
+- `BrokenLinkHealer` (or equivalent orchestrator)
+- `computeUpdatedLinkTarget(...)` for correct path rewriting for moved files
+
+If the final implementation deviates, update this plan and ADR-012 accordingly.
+
+## Work Items (ordered)
+
+### 0) Baseline characterization (no behavior change)
+
+- [ ] Add tests that characterize existing rename + link update behavior:
+  - [ ] filename normalization rename (case/spaces) updates links correctly
+  - [ ] link updates preserve fragments (`#...`) and relative prefixes (`./`, `../`)
+  - [ ] link updates do not touch code blocks / inline code
+
+**Definition of Done**
+
+- Tests pass and clearly document current behavior and limitations.
+
+### 1) Introduce rename mapping type + plumbing hooks
+
+- [ ] Add a small internal type (or reuse existing) that represents `oldAbs -> newAbs` mappings and can be fed into the link update path.
+- [ ] Add unit tests for:
+  - [ ] mapping normalization (absolute paths, docs-root scoping)
+  - [ ] de-duplication and deterministic ordering
+
+**Definition of Done**
+
+- There is a single representation of renames used by both fixer-driven renames and Git-derived renames.
+
+### 2) Git rename detection (uncommitted)
+
+**Intent**: catch the common “pre-commit rename broke links” workflow.
+
+- [ ] Implement/introduce `GitRenameDetector` for uncommitted renames:
+  - [ ] staged renames
+  - [ ] unstaged renames
+- [ ] Ensure it is safe when not in a git repo: returns `(nil, nil)`.
+- [ ] Tests:
+  - [ ] returns mappings for a repo with a `git mv` rename
+  - [ ] ignores non-doc-root renames
+
+**Definition of Done**
+
+- We can produce a reliable set of `(oldAbs, newAbs)` mappings for working tree/index.
+
+### 3) Correct link target rewriting for moved files
+
+This is the key functional delta versus current link updates.
+
+- [ ] Implement `computeUpdatedLinkTarget(sourceFile, originalTarget, oldAbs, newAbs)`.
+- [ ] Unit tests must cover:
+  - [ ] relative link targets (`../a/b.md`) moved across directories
+  - [ ] same-dir links remain minimal
+  - [ ] site-absolute links (`/docs/foo`) stay site-absolute and update correctly
+  - [ ] extension style preserved (`foo` stays `foo` if originally extensionless; `foo.md` stays `.md`)
+  - [ ] fragments preserved (`#section`)
+
+**Definition of Done**
+
+- For moved targets, the updated destination resolves to `newAbs` when interpreted from `sourceFile`.
+
+### 4) Healing strategy: focus on broken links
+
+- [ ] Use existing broken-link detection output as the primary worklist.
+- [ ] For each broken link, resolve the absolute target (existing `resolveRelativePath` behavior) and match against rename mappings.
+- [ ] Apply link updates via existing edit machinery (minimal diffs; no Markdown reformatting).
+- [ ] Ensure fingerprint refresh is triggered for updated files (consistent with current fixer behavior).
+
+**Definition of Done**
+
+- A new healing phase runs during `lint --fix` and produces `LinksUpdated` entries, without requiring the fixer to have performed the rename itself.
+
+### 5) Git history detection (since last push)
+
+- [ ] Detect upstream tracking branch if present.
+- [ ] Extract rename mappings for commits “since last push” (HEAD vs upstream).
+- [ ] Provide bounded fallback when upstream is absent.
+- [ ] Tests:
+  - [ ] uses upstream range when available
+  - [ ] bounded fallback works without upstream
+
+**Definition of Done**
+
+- Broken links can be healed even when the rename was already committed locally.
+
+### 6) Ambiguity + safety
+
+- [ ] Multiple-candidate handling:
+  - [ ] if a broken target maps to multiple plausible new targets, do not rewrite; emit a warning/result entry.
+- [ ] Scope enforcement:
+  - [ ] only heal within configured docs roots
+  - [ ] do not rewrite external links, UID alias links, or Hugo shortcodes
+
+**Definition of Done**
+
+- Healer never rewrites links to out-of-scope targets.
+
+### 7) Verification gate
+
+- [ ] `go test ./... -count=1`
+- [ ] `golangci-lint run --fix` then `golangci-lint run`
+
+## Notes / Risks
+
+- Current `applyLinkUpdates` is filename-focused (basename replace). For moved files, the rewrite must compute a correct new relative path; this should be implemented as a separate function and covered by tests.
+- Avoid O(N renames × M markdown files) behavior; the broken-link list is the natural work queue.

--- a/docs/adr/adr-017-implementation-plan.md
+++ b/docs/adr/adr-017-implementation-plan.md
@@ -4,8 +4,8 @@ aliases:
 categories:
   - architecture-decisions
 date: 2026-01-22T00:00:00Z
-fingerprint: c9937c835e27979ba5dfdcd89eb195bae44a32e54709ded4d5f14af5171c2874
-lastmod: "2026-01-22"
+fingerprint: bdad0c609d039430a4b618f3d4522f03de56086b7d5d48936564750f79f10849
+lastmod: "2026-01-23"
 tags:
   - daemon
   - refactor

--- a/docs/adr/adr-018-vscode-edit-handler-preview-only-routing.md
+++ b/docs/adr/adr-018-vscode-edit-handler-preview-only-routing.md
@@ -1,0 +1,116 @@
+````markdown
+---
+aliases:
+  - /_uid/6b9c3b0c-1f76-45fb-8d3b-7bc8d0d8ab2b/
+categories:
+  - architecture-decisions
+date: 2026-01-23T00:00:00Z
+lastmod: "2026-01-23"
+tags:
+  - vscode
+  - preview
+  - http
+  - security
+  - daemon
+uid: 6b9c3b0c-1f76-45fb-8d3b-7bc8d0d8ab2b
+---
+
+# ADR-018: Register VS Code edit handler only in local preview
+
+**Status**: Proposed  
+**Date**: 2026-01-23  
+**Decision Makers**: DocBuilder Core Team
+
+## Context and Problem Statement
+
+DocBuilder supports “edit links” that can open a local Markdown file in VS Code by hitting an HTTP endpoint:
+
+- `GET /_edit/<relative-path>`
+
+Today, the HTTP docs server mux registers the `/_edit/` route unconditionally, and the handler itself enforces the effective policy:
+
+- If `--vscode` is not enabled, return `404`.
+- If running in daemon mode, return `501` (“preview mode only”).
+
+This behavior is functionally safe but it is not as strict as intended. The endpoint should be a *preview-only* feature and should not appear at all (even as a blocked endpoint) when DocBuilder is running as a daemon.
+
+### Why this matters
+
+- **Principle of least privilege / smaller attack surface**: if daemon mode should never support opening local files via an HTTP-triggered VS Code action, then it should not expose an edit endpoint at all.
+- **Clearer semantics**: a registered-but-blocked endpoint can imply “this exists, but is misconfigured”. For daemon mode, the correct message is “this feature is not part of this product mode”.
+- **Operational hygiene**: probes, scanners, or curious users can hit `/_edit/` and generate warning logs and noise.
+
+## Decision
+
+We will make the VS Code edit endpoint *preview-only at the routing level*:
+
+- The `/_edit/` route is registered **only** when running **local preview**.
+- The route is registered **only** when the feature flag `--vscode` (or equivalent) is enabled.
+- In daemon mode, the docs server will not register `/_edit/` at all, resulting in a normal mux `404`.
+
+We will keep the actual handler implementation in the shared HTTP server package so preview can reuse the same code path, but **route registration becomes conditional** based on runtime mode.
+
+## Definitions
+
+- **Local preview**: the `preview` command (or equivalent preview-mode entrypoint) serving docs from a local filesystem repository and providing developer conveniences.
+- **Daemon mode**: the long-running service mode that manages a repository cache, webhooks, and background build/discovery.
+
+(Exact detection/wiring is an implementation detail; the key is that “preview vs daemon” must be explicit at the HTTP mux wiring layer.)
+
+## Decision Drivers
+
+- Strongly enforce “preview-only” scope.
+- Avoid relying on handler-side checks as the only barrier.
+- Reduce confusion created by a shared `httpserver` package being used by multiple product modes.
+- Preserve the existing UX in local preview (edit links work when enabled).
+
+## Consequences
+
+### Pros
+
+- Daemon no longer exposes `/_edit/` even in a blocked form.
+- Cleaner logs in daemon mode.
+- Makes the security posture easier to explain: “not routed, not reachable”.
+- Removes ambiguity about whether daemon “supports” VS Code edit links.
+
+### Cons / Tradeoffs
+
+- Requires preview/daemon mode to be explicitly represented in HTTP server wiring (either via config flags or server options).
+- Slightly more wiring complexity: mux construction must know whether it is in preview.
+
+## Implementation Notes (Deferred)
+
+This ADR does not implement the change; it describes the intended direction.
+
+A likely implementation approach:
+
+- Introduce an explicit runtime capability or option passed into the HTTP server wiring, e.g. `Options.EnableVSCodeEditHandler` or `Options.Mode = Preview|Daemon`.
+- Register `/_edit/` only when:
+  - `mode == Preview`, and
+  - `cfg.Build.VSCodeEditLinks == true`.
+
+We should keep handler-side validation as defense-in-depth (path validation, symlink checks, etc.), but the primary enforcement becomes “not registered outside preview”.
+
+## Acceptance Criteria
+
+- In daemon mode, requests to `/_edit/...` return `404` because the route is not registered.
+- In local preview with `--vscode` enabled, `/_edit/...` continues to work.
+- In local preview without `--vscode`, the route is not registered (preferred) or returns `404` without logging warnings (acceptable as an incremental step).
+- Tests cover routing behavior differences between preview and daemon modes.
+
+## Alternatives Considered
+
+1. **Keep unconditional routing; rely on handler-side checks**
+   - Rejected: still exposes a discoverable endpoint in daemon mode.
+
+2. **Keep unconditional routing; return `404` in daemon mode instead of `501`**
+   - Rejected: improves semantics but does not reduce attack surface or endpoint discoverability.
+
+3. **Move all VS Code edit logic into preview-only packages**
+   - Not chosen: we still want a shared implementation for edit behavior, just not shared routing.
+
+## Related Documents
+
+- ADR-017: Split daemon responsibilities (package boundaries)
+
+````

--- a/docs/adr/adr-018-vscode-edit-handler-preview-only-routing.md
+++ b/docs/adr/adr-018-vscode-edit-handler-preview-only-routing.md
@@ -1,10 +1,10 @@
-````markdown
 ---
 aliases:
   - /_uid/6b9c3b0c-1f76-45fb-8d3b-7bc8d0d8ab2b/
 categories:
   - architecture-decisions
 date: 2026-01-23T00:00:00Z
+fingerprint: 16664189e38f1c60b592da8f3bbc762ff896ccd24400c8e43ba606240b648639
 lastmod: "2026-01-23"
 tags:
   - vscode
@@ -112,5 +112,3 @@ We should keep handler-side validation as defense-in-depth (path validation, sym
 ## Related Documents
 
 - ADR-017: Split daemon responsibilities (package boundaries)
-
-````

--- a/internal/lint/broken_link_healer.go
+++ b/internal/lint/broken_link_healer.go
@@ -1,0 +1,203 @@
+package lint
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+type mappingKey struct {
+	oldAbs string
+	newAbs string
+}
+
+func (f *Fixer) healBrokenLinksFromGitRenames(rootPath string, brokenLinks []BrokenLink, fixResult *FixResult, fingerprintTargets map[string]struct{}) {
+	if f.dryRun {
+		return
+	}
+	if len(brokenLinks) == 0 {
+		return
+	}
+
+	docsRoot := docsRootFromPath(rootPath)
+	repoDir := repoDirFromPath(rootPath)
+	repoDir = gitTopLevelOrSelf(context.Background(), repoDir)
+
+	mappings, err := detectScopedGitRenames(context.Background(), repoDir, docsRoot)
+	if err != nil {
+		fixResult.Errors = append(fixResult.Errors, err)
+		return
+	}
+	if len(mappings) == 0 {
+		return
+	}
+
+	byOld := indexRenamesByOld(mappings)
+	linksByMapping := collectLinksByMapping(f, brokenLinks, byOld)
+	if len(linksByMapping) == 0 {
+		return
+	}
+
+	applyHealedLinkUpdates(f, linksByMapping, fixResult, fingerprintTargets)
+}
+
+func docsRootFromPath(path string) string {
+	if info, statErr := os.Stat(path); statErr == nil && !info.IsDir() {
+		return filepath.Dir(path)
+	}
+	return path
+}
+
+func repoDirFromPath(path string) string {
+	if info, statErr := os.Stat(path); statErr == nil && !info.IsDir() {
+		return filepath.Dir(path)
+	}
+	return path
+}
+
+func gitTopLevelOrSelf(ctx context.Context, dir string) string {
+	if top, ok := gitTopLevelDir(ctx, dir); ok {
+		return top
+	}
+	return dir
+}
+
+func detectScopedGitRenames(ctx context.Context, repoDir string, docsRoot string) ([]RenameMapping, error) {
+	detector := &GitUncommittedRenameDetector{}
+	mappings, err := detector.DetectRenames(ctx, repoDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect git renames: %w", err)
+	}
+	if len(mappings) == 0 {
+		return nil, nil
+	}
+
+	normalized, err := NormalizeRenameMappings(mappings, []string{docsRoot})
+	if err != nil {
+		return nil, fmt.Errorf("failed to normalize rename mappings: %w", err)
+	}
+	return normalized, nil
+}
+
+func indexRenamesByOld(mappings []RenameMapping) map[string]RenameMapping {
+	byOld := make(map[string]RenameMapping, len(mappings))
+	for _, m := range mappings {
+		byOld[strings.ToLower(filepath.ToSlash(filepath.Clean(m.OldAbs)))] = m
+	}
+	return byOld
+}
+
+func collectLinksByMapping(f *Fixer, brokenLinks []BrokenLink, byOld map[string]RenameMapping) map[mappingKey][]LinkReference {
+	linksByMapping := make(map[mappingKey][]LinkReference)
+	linkCache := make(map[string][]LinkReference)
+
+	for _, bl := range brokenLinks {
+		resolved, err := resolveRelativePath(bl.SourceFile, bl.Target)
+		if err != nil {
+			continue
+		}
+
+		mapping, ok := lookupRenameMapping(byOld, resolved)
+		if !ok {
+			continue
+		}
+
+		cacheKey := bl.SourceFile + "\x00" + mapping.OldAbs
+		references, ok := linkCache[cacheKey]
+		if !ok {
+			references, err = f.findLinksInFile(bl.SourceFile, mapping.OldAbs)
+			if err != nil {
+				continue
+			}
+			linkCache[cacheKey] = references
+		}
+		if len(references) == 0 {
+			continue
+		}
+
+		mk := mappingKey{oldAbs: mapping.OldAbs, newAbs: mapping.NewAbs}
+		linksByMapping[mk] = append(linksByMapping[mk], references...)
+	}
+
+	return linksByMapping
+}
+
+func lookupRenameMapping(byOld map[string]RenameMapping, resolvedAbs string) (RenameMapping, bool) {
+	candidates := candidateOldPaths(resolvedAbs)
+	for _, c := range candidates {
+		key := strings.ToLower(filepath.ToSlash(filepath.Clean(c)))
+		m, ok := byOld[key]
+		if ok {
+			return m, true
+		}
+	}
+	return RenameMapping{}, false
+}
+
+func candidateOldPaths(resolvedAbs string) []string {
+	candidates := []string{resolvedAbs}
+	switch strings.ToLower(filepath.Ext(resolvedAbs)) {
+	case "", ".html", ".htm":
+		candidates = append(candidates, resolvedAbs+docExtensionMarkdown, resolvedAbs+docExtensionMarkdownLong)
+	default:
+		if hasKnownMarkdownExtension(resolvedAbs) {
+			candidates = append(candidates, stripKnownMarkdownExtension(resolvedAbs))
+		}
+	}
+	return candidates
+}
+
+func applyHealedLinkUpdates(f *Fixer, linksByMapping map[mappingKey][]LinkReference, fixResult *FixResult, fingerprintTargets map[string]struct{}) {
+	for mk, refs := range linksByMapping {
+		updates, err := f.applyLinkUpdates(refs, mk.oldAbs, mk.newAbs)
+		if err != nil {
+			fixResult.Errors = append(fixResult.Errors, err)
+			continue
+		}
+
+		fixResult.LinksUpdated = append(fixResult.LinksUpdated, updates...)
+		pruneBrokenLinksFromUpdates(fixResult, updates)
+
+		for _, upd := range updates {
+			fingerprintTargets[upd.SourceFile] = struct{}{}
+		}
+	}
+}
+
+func pruneBrokenLinksFromUpdates(fixResult *FixResult, updates []LinkUpdate) {
+	if len(updates) == 0 || len(fixResult.BrokenLinks) == 0 {
+		return
+	}
+
+	fixed := make(map[string]struct{}, len(updates))
+	for _, upd := range updates {
+		fixed[upd.SourceFile+"\x00"+upd.OldTarget] = struct{}{}
+	}
+
+	remaining := make([]BrokenLink, 0, len(fixResult.BrokenLinks))
+	for _, bl := range fixResult.BrokenLinks {
+		if _, ok := fixed[bl.SourceFile+"\x00"+bl.Target]; ok {
+			continue
+		}
+		remaining = append(remaining, bl)
+	}
+	fixResult.BrokenLinks = remaining
+}
+
+func gitTopLevelDir(ctx context.Context, dir string) (string, bool) {
+	// #nosec G204 -- invoking git with fixed binary name and controlled args
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--show-toplevel")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	trimmed := bytes.TrimSpace(out)
+	if len(trimmed) == 0 {
+		return "", false
+	}
+	return string(trimmed), true
+}

--- a/internal/lint/fixer.go
+++ b/internal/lint/fixer.go
@@ -115,6 +115,7 @@ func (f *Fixer) fix(path string) (*FixResult, error) {
 		LinksUpdated: make([]LinkUpdate, 0),
 		Fingerprints: make([]FingerprintUpdate, 0),
 		BrokenLinks:  make([]BrokenLink, 0),
+		HealSkipped:  make([]BrokenLinkHealSkip, 0),
 		Errors:       make([]error, 0),
 	}
 

--- a/internal/lint/fixer_broken_link_heal_test.go
+++ b/internal/lint/fixer_broken_link_heal_test.go
@@ -48,3 +48,93 @@ func TestFixer_HealsBrokenLinks_FromGitUncommittedRename(t *testing.T) {
 	// Ensure the update is recorded.
 	require.NotEmpty(t, res.LinksUpdated)
 }
+
+func TestFixer_SkipsBrokenLinkHealing_WhenRenameMappingIsAmbiguous(t *testing.T) {
+	repoDir := initGitRepo(t)
+	docsDir := filepath.Join(repoDir, "docs")
+	require.NoError(t, os.MkdirAll(docsDir, 0o750))
+
+	oldFoo := filepath.Join(docsDir, "Foo.md")
+	oldfoo := filepath.Join(docsDir, "foo.md")
+	indexFile := filepath.Join(docsDir, "index.md")
+
+	require.NoError(t, os.WriteFile(oldFoo, []byte("# Foo\n"), 0o600))
+	require.NoError(t, os.WriteFile(oldfoo, []byte("# foo\n"), 0o600))
+	// Use a case-mismatched link target so it won't match the exact-case mapping,
+	// forcing the healer into its case-insensitive matching path.
+	require.NoError(t, os.WriteFile(indexFile, []byte("[Foo](FOO.md)\n"), 0o600))
+
+	git(t, repoDir, "add", "docs/Foo.md", "docs/foo.md", "docs/index.md")
+	git(t, repoDir, "commit", "-m", "add docs")
+
+	// User renames both files (staged renames) and forgets to update links.
+	git(t, repoDir, "mv", "docs/Foo.md", "docs/FooNew.md")
+	git(t, repoDir, "mv", "docs/foo.md", "docs/fooNew.md")
+
+	// Sanity: link is currently broken.
+	before, err := detectBrokenLinks(indexFile)
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+
+	linter := NewLinter(&Config{Format: "text"})
+	fixer := NewFixer(linter, false, true)
+	// Fix only the linking file so filename-convention renames on other files
+	// cannot affect ambiguity detection.
+	res, err := fixer.fix(indexFile)
+	require.NoError(t, err)
+
+	// The broken link remains (healing is skipped for ambiguity).
+	require.Len(t, res.BrokenLinks, 1)
+	require.Empty(t, res.LinksUpdated)
+	require.Len(t, res.HealSkipped, 1)
+	require.Contains(t, res.HealSkipped[0].Reason, "ambiguous")
+	require.Len(t, res.HealSkipped[0].Candidates, 2)
+
+	// Link target should remain unchanged.
+	// #nosec G304 -- test reads from a tempdir path
+	data, err := os.ReadFile(indexFile)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "[Foo](FOO.md)")
+}
+
+func TestFixer_HealsBrokenLinks_ToFinalPath_WhenFixerAlsoRenamesDestination(t *testing.T) {
+	repoDir := initGitRepo(t)
+	docsDir := filepath.Join(repoDir, "docs")
+	require.NoError(t, os.MkdirAll(filepath.Join(docsDir, "subdir"), 0o750))
+
+	oldTarget := filepath.Join(docsDir, "file.md")
+	indexFile := filepath.Join(docsDir, "index.md")
+	require.NoError(t, os.WriteFile(oldTarget, []byte("# Target\n"), 0o600))
+	require.NoError(t, os.WriteFile(indexFile, []byte("[Go](file.md)\n"), 0o600))
+
+	git(t, repoDir, "add", "docs/file.md", "docs/index.md")
+	git(t, repoDir, "commit", "-m", "add docs")
+
+	// User moves the file into a subdir with an uppercase filename.
+	git(t, repoDir, "mv", "docs/file.md", "docs/subdir/File.md")
+
+	// Sanity: link is currently broken.
+	before, err := detectBrokenLinks(docsDir)
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+
+	linter := NewLinter(&Config{Format: "text"})
+	fixer := NewFixer(linter, false, true)
+	res, err := fixer.fix(docsDir)
+	require.NoError(t, err)
+
+	// Destination should be normalized by the fixer.
+	finalTarget := filepath.Join(docsDir, "subdir", "file.md")
+	require.FileExists(t, finalTarget)
+
+	// Healing should update links to the FINAL path (subdir/file.md), not the
+	// intermediate Git rename destination (subdir/File.md).
+	// #nosec G304 -- test reads from a tempdir path
+	data, err := os.ReadFile(indexFile)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "[Go](subdir/file.md)")
+	require.NotContains(t, string(data), "subdir/File.md")
+
+	// And the broken link worklist should be fully healed.
+	require.Empty(t, res.BrokenLinks)
+}

--- a/internal/lint/fixer_broken_link_heal_test.go
+++ b/internal/lint/fixer_broken_link_heal_test.go
@@ -1,0 +1,50 @@
+package lint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFixer_HealsBrokenLinks_FromGitUncommittedRename(t *testing.T) {
+	repoDir := initGitRepo(t)
+	docsDir := filepath.Join(repoDir, "docs")
+	require.NoError(t, os.MkdirAll(filepath.Join(docsDir, "old"), 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(docsDir, "new"), 0o750))
+
+	oldTarget := filepath.Join(docsDir, "old", "target.md")
+	indexFile := filepath.Join(docsDir, "index.md")
+
+	require.NoError(t, os.WriteFile(oldTarget, []byte("# Target\n"), 0o600))
+	require.NoError(t, os.WriteFile(indexFile, []byte("[Go](old/target.md)\n"), 0o600))
+
+	git(t, repoDir, "add", "docs/old/target.md", "docs/index.md")
+	git(t, repoDir, "commit", "-m", "add docs")
+
+	// User moves the file (staged rename) and forgets to update links.
+	git(t, repoDir, "mv", "docs/old/target.md", "docs/new/target.md")
+
+	// Sanity: link is currently broken.
+	before, err := detectBrokenLinks(docsDir)
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+
+	linter := NewLinter(&Config{Format: "text"})
+	fixer := NewFixer(linter, false, true)
+	res, err := fixer.fix(docsDir)
+	require.NoError(t, err)
+
+	// The broken link should be healed and no broken links should remain.
+	require.Empty(t, res.BrokenLinks)
+
+	// The index link should now point at the new location.
+	// #nosec G304 -- test reads from a tempdir path
+	data, err := os.ReadFile(indexFile)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "[Go](new/target.md)")
+
+	// Ensure the update is recorded.
+	require.NotEmpty(t, res.LinksUpdated)
+}

--- a/internal/lint/git_history_rename_detector.go
+++ b/internal/lint/git_history_rename_detector.go
@@ -1,0 +1,174 @@
+package lint
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+)
+
+const defaultHistoryFallbackCommits = 50
+
+// GitHistoryRenameDetector detects renames that have already been committed
+// in Git history, typically for commits that exist locally but are not yet
+// present on the upstream tracking branch.
+//
+// This is a building block for ADR-012.
+//
+// Behavior:
+//   - If repoRoot is not a git repository, it returns an empty slice and nil error.
+//   - If an upstream tracking branch exists, it uses the range upstream..HEAD.
+//   - If upstream is absent, it uses a bounded fallback range based on the last
+//     N commits (defaultHistoryFallbackCommits).
+//
+// It uses the git CLI to leverage Git's rename detection.
+type GitHistoryRenameDetector struct {
+	// MaxCommits bounds the fallback range when upstream is absent.
+	// If zero, defaultHistoryFallbackCommits is used.
+	MaxCommits int
+}
+
+func (d *GitHistoryRenameDetector) DetectRenames(ctx context.Context, repoRoot string) ([]RenameMapping, error) {
+	repoRootAbs, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make repo root absolute: %w", err)
+	}
+
+	isGit := isGitWorkTree(ctx, repoRootAbs)
+	if !isGit {
+		return nil, nil
+	}
+
+	upstream, hasUpstream := gitUpstreamRef(ctx, repoRootAbs)
+	if hasUpstream {
+		mappings, diffErr := gitDiffRenamesRange(ctx, repoRootAbs, upstream+"..HEAD")
+		if diffErr != nil {
+			return nil, diffErr
+		}
+		for i := range mappings {
+			mappings[i].Source = RenameSourceGitHistory
+		}
+		return NormalizeRenameMappings(mappings, nil)
+	}
+
+	maxCommits := d.MaxCommits
+	if maxCommits <= 0 {
+		maxCommits = defaultHistoryFallbackCommits
+	}
+
+	base, ok := gitFallbackBaseCommit(ctx, repoRootAbs, maxCommits)
+	if !ok {
+		return nil, nil
+	}
+
+	mappings, err := gitDiffRenamesRange(ctx, repoRootAbs, base+"..HEAD")
+	if err != nil {
+		return nil, err
+	}
+	for i := range mappings {
+		mappings[i].Source = RenameSourceGitHistory
+	}
+	return NormalizeRenameMappings(mappings, nil)
+}
+
+func gitUpstreamRef(ctx context.Context, repoRoot string) (string, bool) {
+	// #nosec G204 -- invoking git with fixed binary name and controlled args
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	trimmed := bytes.TrimSpace(out)
+	if len(trimmed) == 0 {
+		return "", false
+	}
+	return string(trimmed), true
+}
+
+func gitFallbackBaseCommit(ctx context.Context, repoRoot string, maxCommits int) (base string, ok bool) {
+	if maxCommits <= 0 {
+		return "", false
+	}
+
+	// Determine whether HEAD~(maxCommits) exists; if it doesn't (small history),
+	// HEAD~1 may still exist.
+	for n := maxCommits; n >= 1; n-- {
+		candidate := fmt.Sprintf("HEAD~%d", n)
+		if gitRevParseOK(ctx, repoRoot, candidate) {
+			return candidate, true
+		}
+	}
+
+	// No ancestors (repo with 0 or 1 commit).
+	return "", false
+}
+
+func gitRevParseOK(ctx context.Context, repoRoot string, rev string) bool {
+	// #nosec G204 -- invoking git with fixed binary name and controlled args
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "rev-parse", "--verify", "-q", rev)
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+	return true
+}
+
+func gitDiffRenamesRange(ctx context.Context, repoRoot string, rangeSpec string) ([]RenameMapping, error) {
+	args := []string{"-C", repoRoot, "diff", "--name-status", "-z", "-M", rangeSpec}
+
+	// #nosec G204 -- invoking git with fixed binary name and controlled args
+	cmd := exec.CommandContext(ctx, "git", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return nil, fmt.Errorf("git diff %s failed: %w: %s", rangeSpec, err, string(ee.Stderr))
+		}
+		return nil, fmt.Errorf("git diff %s failed: %w", rangeSpec, err)
+	}
+
+	if len(out) == 0 {
+		return nil, nil
+	}
+
+	tokens := bytes.Split(out, []byte{0})
+	mappings := make([]RenameMapping, 0)
+	for i := 0; i < len(tokens); {
+		if len(tokens[i]) == 0 {
+			i++
+			continue
+		}
+		status := string(tokens[i])
+		i++
+
+		if len(status) > 0 && status[0] == 'R' {
+			if i+1 >= len(tokens) {
+				break
+			}
+			oldRel := string(tokens[i])
+			newRel := string(tokens[i+1])
+			i += 2
+
+			oldAbs, okOld := repoAbsPath(repoRoot, oldRel)
+			newAbs, okNew := repoAbsPath(repoRoot, newRel)
+			if !okOld || !okNew {
+				continue
+			}
+
+			mappings = append(mappings, RenameMapping{
+				OldAbs: oldAbs,
+				NewAbs: newAbs,
+				Source: RenameSourceGitHistory,
+			})
+			continue
+		}
+
+		// Non-rename entries have a single path token.
+		if i < len(tokens) {
+			i++
+		}
+	}
+
+	return mappings, nil
+}

--- a/internal/lint/git_history_rename_detector_test.go
+++ b/internal/lint/git_history_rename_detector_test.go
@@ -1,0 +1,90 @@
+package lint
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitHistoryRenameDetector_NotAGitRepo_ReturnsEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	detector := &GitHistoryRenameDetector{}
+
+	got, err := detector.DetectRenames(context.Background(), tmpDir)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestGitHistoryRenameDetector_UsesUpstreamRangeWhenAvailable(t *testing.T) {
+	ctx := context.Background()
+	repoDir := initGitRepo(t)
+
+	// Ensure we're on main to simplify upstream setup.
+	git(t, repoDir, "checkout", "-b", "main")
+
+	docsDir := filepath.Join(repoDir, "docs")
+	require.NoError(t, os.MkdirAll(docsDir, 0o750))
+
+	oldPath := filepath.Join(docsDir, "old.md")
+	newPath := filepath.Join(docsDir, "new.md")
+	require.NoError(t, os.WriteFile(oldPath, []byte("# Hello\n"), 0o600))
+
+	git(t, repoDir, "add", "docs/old.md")
+	git(t, repoDir, "commit", "-m", "add old")
+
+	// Create a bare remote and push, setting upstream.
+	remoteDir := t.TempDir()
+	git(t, remoteDir, "init", "--bare")
+	git(t, repoDir, "remote", "add", "origin", remoteDir)
+	git(t, repoDir, "push", "-u", "origin", "main")
+
+	// Now commit a rename locally (not pushed).
+	git(t, repoDir, "mv", "docs/old.md", "docs/new.md")
+	git(t, repoDir, "commit", "-m", "rename old to new")
+
+	detector := &GitHistoryRenameDetector{}
+	got, err := detector.DetectRenames(ctx, repoDir)
+	require.NoError(t, err)
+
+	got, err = NormalizeRenameMappings(got, []string{docsDir})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, oldPath, got[0].OldAbs)
+	assert.Equal(t, newPath, got[0].NewAbs)
+	assert.Equal(t, RenameSourceGitHistory, got[0].Source)
+}
+
+func TestGitHistoryRenameDetector_FallbackWhenNoUpstream(t *testing.T) {
+	ctx := context.Background()
+	repoDir := initGitRepo(t)
+
+	docsDir := filepath.Join(repoDir, "docs")
+	require.NoError(t, os.MkdirAll(docsDir, 0o750))
+
+	oldPath := filepath.Join(docsDir, "old.md")
+	newPath := filepath.Join(docsDir, "new.md")
+	require.NoError(t, os.WriteFile(oldPath, []byte("# Hello\n"), 0o600))
+
+	git(t, repoDir, "add", "docs/old.md")
+	git(t, repoDir, "commit", "-m", "add old")
+
+	git(t, repoDir, "mv", "docs/old.md", "docs/new.md")
+	git(t, repoDir, "commit", "-m", "rename old to new")
+
+	detector := &GitHistoryRenameDetector{}
+	got, err := detector.DetectRenames(ctx, repoDir)
+	require.NoError(t, err)
+
+	got, err = NormalizeRenameMappings(got, []string{docsDir})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, oldPath, got[0].OldAbs)
+	assert.Equal(t, newPath, got[0].NewAbs)
+	assert.Equal(t, RenameSourceGitHistory, got[0].Source)
+}

--- a/internal/lint/git_uncommitted_rename_detector.go
+++ b/internal/lint/git_uncommitted_rename_detector.go
@@ -1,0 +1,264 @@
+package lint
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// GitUncommittedRenameDetector detects renames in the working tree and index
+// (i.e., changes that may not be committed yet).
+//
+// It uses the git CLI because uncommitted renames are most naturally represented
+// via the index/working-tree diffs.
+//
+// If repoRoot is not a git repository, it returns an empty slice and nil error.
+//
+// This is a building block for ADR-012.
+type GitUncommittedRenameDetector struct{}
+
+func (d *GitUncommittedRenameDetector) DetectRenames(ctx context.Context, repoRoot string) ([]RenameMapping, error) {
+	repoRootAbs, err := filepath.Abs(repoRoot)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make repo root absolute: %w", err)
+	}
+
+	isGit := isGitWorkTree(ctx, repoRootAbs)
+	if !isGit {
+		return nil, nil
+	}
+
+	staged, err := gitDiffRenames(ctx, repoRootAbs, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// Best-effort: detect unstaged renames.
+	// `git diff` does not consider untracked files, so a plain filesystem rename
+	// often appears as "D old" + "?? new". We bridge that by matching deleted
+	// index content to untracked file content.
+	unstaged, err := detectUnstagedRenamesFromDeletedPlusUntracked(ctx, repoRootAbs)
+	if err != nil {
+		return nil, err
+	}
+
+	staged = append(staged, unstaged...)
+	return NormalizeRenameMappings(staged, nil)
+}
+
+func isGitWorkTree(ctx context.Context, repoRoot string) bool {
+	// #nosec G204 -- invoking git with fixed binary name and controlled args
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "rev-parse", "--is-inside-work-tree")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// Not a git repo (or git unavailable). Treat as "no git" without error.
+		return false
+	}
+	trimmed := bytes.TrimSpace(out)
+	return bytes.Equal(trimmed, []byte("true"))
+}
+
+func gitDiffRenames(ctx context.Context, repoRoot string, cached bool) ([]RenameMapping, error) {
+	args := []string{"-C", repoRoot, "diff", "--name-status", "-z", "-M"}
+	if cached {
+		args = append(args, "--cached")
+	}
+
+	// #nosec G204 -- invoking git with fixed binary name and controlled args
+	cmd := exec.CommandContext(ctx, "git", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return nil, fmt.Errorf("git diff failed: %w: %s", err, string(ee.Stderr))
+		}
+		return nil, fmt.Errorf("git diff failed: %w", err)
+	}
+
+	if len(out) == 0 {
+		return nil, nil
+	}
+
+	tokens := bytes.Split(out, []byte{0})
+	mappings := make([]RenameMapping, 0)
+	for i := 0; i < len(tokens); {
+		if len(tokens[i]) == 0 {
+			i++
+			continue
+		}
+		status := string(tokens[i])
+		i++
+
+		if len(status) > 0 && status[0] == 'R' {
+			if i+1 >= len(tokens) {
+				break
+			}
+			oldRel := string(tokens[i])
+			newRel := string(tokens[i+1])
+			i += 2
+
+			oldAbs, okOld := repoAbsPath(repoRoot, oldRel)
+			newAbs, okNew := repoAbsPath(repoRoot, newRel)
+			if !okOld || !okNew {
+				continue
+			}
+
+			mappings = append(mappings, RenameMapping{
+				OldAbs: oldAbs,
+				NewAbs: newAbs,
+				Source: RenameSourceGitUncommitted,
+			})
+			continue
+		}
+
+		// Non-rename entries have a single path token.
+		if i < len(tokens) {
+			i++
+		}
+	}
+
+	return mappings, nil
+}
+
+func detectUnstagedRenamesFromDeletedPlusUntracked(ctx context.Context, repoRoot string) ([]RenameMapping, error) {
+	deletedRel, err := gitNameOnly(ctx, repoRoot, []string{"diff", "--name-only", "-z", "--diff-filter=D"})
+	if err != nil {
+		return nil, err
+	}
+	if len(deletedRel) == 0 {
+		return nil, nil
+	}
+
+	untrackedRel, err := gitNameOnly(ctx, repoRoot, []string{"ls-files", "--others", "--exclude-standard", "-z"})
+	if err != nil {
+		return nil, err
+	}
+	if len(untrackedRel) == 0 {
+		return nil, nil
+	}
+
+	// Hash untracked files by content.
+	untrackedByHash := make(map[[32]byte][]string, len(untrackedRel))
+	for _, rel := range untrackedRel {
+		abs, ok := repoAbsPath(repoRoot, rel)
+		if !ok {
+			continue
+		}
+
+		// #nosec G304 -- path is validated to remain within repoRoot
+		b, readErr := os.ReadFile(abs)
+		if readErr != nil {
+			continue
+		}
+		h := sha256.Sum256(b)
+		untrackedByHash[h] = append(untrackedByHash[h], rel)
+	}
+
+	var mappings []RenameMapping
+	for _, oldRel := range deletedRel {
+		oldContent, err := gitShowIndexFile(ctx, repoRoot, oldRel)
+		if err != nil {
+			continue
+		}
+		oldHash := sha256.Sum256(oldContent)
+		candidates := untrackedByHash[oldHash]
+		if len(candidates) != 1 {
+			// Ambiguous or no match.
+			continue
+		}
+		newRel := candidates[0]
+		oldAbs, okOld := repoAbsPath(repoRoot, oldRel)
+		newAbs, okNew := repoAbsPath(repoRoot, newRel)
+		if !okOld || !okNew {
+			continue
+		}
+		mappings = append(mappings, RenameMapping{
+			OldAbs: oldAbs,
+			NewAbs: newAbs,
+			Source: RenameSourceGitUncommitted,
+		})
+	}
+
+	return mappings, nil
+}
+
+func gitNameOnly(ctx context.Context, repoRoot string, args []string) ([]string, error) {
+	// #nosec G204 -- invoking git with fixed binary name and controlled args
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", repoRoot}, args...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return nil, fmt.Errorf("git %v failed: %w: %s", args, err, string(ee.Stderr))
+		}
+		return nil, fmt.Errorf("git %v failed: %w", args, err)
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+
+	parts := bytes.Split(out, []byte{0})
+	res := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if len(p) == 0 {
+			continue
+		}
+		res = append(res, string(p))
+	}
+	return res, nil
+}
+
+func gitShowIndexFile(ctx context.Context, repoRoot, relPath string) ([]byte, error) {
+	// `:<path>` reads the blob from the index.
+	spec := ":" + relPath
+	// #nosec G204 -- invoking git with fixed binary name and controlled args
+	cmd := exec.CommandContext(ctx, "git", "-C", repoRoot, "show", spec)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	b, readErr := io.ReadAll(stdout)
+	waitErr := cmd.Wait()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if waitErr != nil {
+		return nil, waitErr
+	}
+	return b, nil
+}
+
+func repoAbsPath(repoRoot, relPath string) (string, bool) {
+	if relPath == "" {
+		return "", false
+	}
+	if filepath.IsAbs(relPath) {
+		return "", false
+	}
+
+	cleaned := filepath.Clean(filepath.FromSlash(relPath))
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+
+	abs := filepath.Join(repoRoot, cleaned)
+	relToRoot, err := filepath.Rel(repoRoot, abs)
+	if err != nil {
+		return "", false
+	}
+	if relToRoot == ".." || strings.HasPrefix(relToRoot, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+
+	return abs, true
+}

--- a/internal/lint/git_uncommitted_rename_detector_test.go
+++ b/internal/lint/git_uncommitted_rename_detector_test.go
@@ -1,0 +1,128 @@
+package lint
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitUncommittedRenameDetector_NotAGitRepo_ReturnsEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	detector := &GitUncommittedRenameDetector{}
+
+	got, err := detector.DetectRenames(context.Background(), tmpDir)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestGitUncommittedRenameDetector_DetectsStagedRename_GitMv(t *testing.T) {
+	ctx := context.Background()
+	repoDir := initGitRepo(t)
+
+	docsDir := filepath.Join(repoDir, "docs")
+	require.NoError(t, os.MkdirAll(docsDir, 0o750))
+
+	oldPath := filepath.Join(docsDir, "old.md")
+	newPath := filepath.Join(docsDir, "new.md")
+	require.NoError(t, os.WriteFile(oldPath, []byte("# Hello\n"), 0o600))
+
+	git(t, repoDir, "add", "docs/old.md")
+	git(t, repoDir, "commit", "-m", "add old")
+
+	git(t, repoDir, "mv", "docs/old.md", "docs/new.md")
+
+	detector := &GitUncommittedRenameDetector{}
+	got, err := detector.DetectRenames(ctx, repoDir)
+	require.NoError(t, err)
+
+	// Normalize to docs-root scope, to match the intended pipeline behavior.
+	got, err = NormalizeRenameMappings(got, []string{docsDir})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, oldPath, got[0].OldAbs)
+	assert.Equal(t, newPath, got[0].NewAbs)
+	assert.Equal(t, RenameSourceGitUncommitted, got[0].Source)
+}
+
+func TestGitUncommittedRenameDetector_DetectsUnstagedRename_FileMove(t *testing.T) {
+	ctx := context.Background()
+	repoDir := initGitRepo(t)
+
+	docsDir := filepath.Join(repoDir, "docs")
+	require.NoError(t, os.MkdirAll(docsDir, 0o750))
+
+	oldPath := filepath.Join(docsDir, "old.md")
+	newPath := filepath.Join(docsDir, "new.md")
+	require.NoError(t, os.WriteFile(oldPath, []byte("# Hello\n"), 0o600))
+
+	git(t, repoDir, "add", "docs/old.md")
+	git(t, repoDir, "commit", "-m", "add old")
+
+	// Simulate a user rename outside of git mv (unstaged in index).
+	require.NoError(t, os.Rename(oldPath, newPath))
+
+	detector := &GitUncommittedRenameDetector{}
+	got, err := detector.DetectRenames(ctx, repoDir)
+	require.NoError(t, err)
+
+	got, err = NormalizeRenameMappings(got, []string{docsDir})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, oldPath, got[0].OldAbs)
+	assert.Equal(t, newPath, got[0].NewAbs)
+	assert.Equal(t, RenameSourceGitUncommitted, got[0].Source)
+}
+
+func TestGitUncommittedRenameDetector_IgnoresNonDocsRootRenames_AfterNormalization(t *testing.T) {
+	ctx := context.Background()
+	repoDir := initGitRepo(t)
+
+	docsDir := filepath.Join(repoDir, "docs")
+	otherDir := filepath.Join(repoDir, "other")
+	require.NoError(t, os.MkdirAll(docsDir, 0o750))
+	require.NoError(t, os.MkdirAll(otherDir, 0o750))
+
+	oldDoc := filepath.Join(otherDir, "old.md")
+	require.NoError(t, os.WriteFile(oldDoc, []byte("# Hello\n"), 0o600))
+
+	git(t, repoDir, "add", "other/old.md")
+	git(t, repoDir, "commit", "-m", "add other")
+
+	git(t, repoDir, "mv", "other/old.md", "other/new.md")
+
+	detector := &GitUncommittedRenameDetector{}
+	got, err := detector.DetectRenames(ctx, repoDir)
+	require.NoError(t, err)
+
+	got, err = NormalizeRenameMappings(got, []string{docsDir})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func initGitRepo(t *testing.T) string {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	git(t, repoDir, "init")
+	git(t, repoDir, "config", "user.email", "test@example.com")
+	git(t, repoDir, "config", "user.name", "Test")
+	return repoDir
+}
+
+func git(t *testing.T, repoDir string, args ...string) {
+	t.Helper()
+
+	// #nosec G204 -- test helper executing git with controlled args
+	cmd := exec.CommandContext(context.Background(), "git", append([]string{"-C", repoDir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, string(out))
+	}
+}

--- a/internal/lint/link_target_rewrite.go
+++ b/internal/lint/link_target_rewrite.go
@@ -1,0 +1,106 @@
+package lint
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// computeUpdatedLinkTarget computes the new link destination text when a target
+// file has moved from oldAbs to newAbs.
+//
+// It must preserve:
+// - link style (site-absolute vs relative)
+// - extension style ("foo" vs "foo.md")
+// - fragments ("#...").
+func computeUpdatedLinkTarget(sourceFile string, originalTarget string, oldAbs string, newAbs string) (newTarget string, changed bool, err error) {
+	_ = oldAbs // validation happens at call sites (broken link resolution)
+
+	if originalTarget == "" {
+		return "", false, nil
+	}
+	if strings.HasPrefix(originalTarget, "#") {
+		return originalTarget, false, nil
+	}
+
+	pathPart, fragment := splitFragment(originalTarget)
+	if pathPart == "" {
+		return originalTarget, false, nil
+	}
+	if hasURLScheme(pathPart) {
+		return originalTarget, false, nil
+	}
+
+	hasMarkdownExt := hasKnownMarkdownExtension(pathPart)
+	wantsDotSlash := strings.HasPrefix(pathPart, "./")
+	isSiteAbsolute := strings.HasPrefix(pathPart, "/")
+
+	updatedPath, err := computeUpdatedLinkPath(sourceFile, newAbs, isSiteAbsolute, wantsDotSlash)
+	if err != nil {
+		return "", false, err
+	}
+
+	if !hasMarkdownExt {
+		updatedPath = stripKnownMarkdownExtension(updatedPath)
+	}
+
+	newTarget = updatedPath + fragment
+	return newTarget, newTarget != originalTarget, nil
+}
+
+func computeUpdatedLinkPath(sourceFile string, newAbs string, isSiteAbsolute bool, wantsDotSlash bool) (string, error) {
+	if isSiteAbsolute {
+		contentRoot := findContentRoot(sourceFile)
+		if contentRoot == "" {
+			return "", fmt.Errorf("failed to compute site-absolute link: content root not found for %q", sourceFile)
+		}
+		rel, err := filepath.Rel(contentRoot, newAbs)
+		if err != nil {
+			return "", fmt.Errorf("failed to compute site-absolute link relpath: %w", err)
+		}
+		return "/" + filepath.ToSlash(rel), nil
+	}
+
+	sourceDir := filepath.Dir(sourceFile)
+	rel, err := filepath.Rel(sourceDir, newAbs)
+	if err != nil {
+		return "", fmt.Errorf("failed to compute relative link relpath: %w", err)
+	}
+	updatedPath := filepath.ToSlash(rel)
+	if wantsDotSlash && !strings.HasPrefix(updatedPath, "../") && !strings.HasPrefix(updatedPath, "./") {
+		updatedPath = "./" + updatedPath
+	}
+	return updatedPath, nil
+}
+
+func splitFragment(target string) (pathPart string, fragment string) {
+	idx := strings.Index(target, "#")
+	if idx == -1 {
+		return target, ""
+	}
+	return target[:idx], target[idx:]
+}
+
+func hasURLScheme(target string) bool {
+	lower := strings.ToLower(target)
+	return strings.HasPrefix(lower, "http://") ||
+		strings.HasPrefix(lower, "https://") ||
+		strings.HasPrefix(lower, "mailto:") ||
+		strings.HasPrefix(lower, "tel:")
+}
+
+func hasKnownMarkdownExtension(target string) bool {
+	lower := strings.ToLower(target)
+	return strings.HasSuffix(lower, ".md") || strings.HasSuffix(lower, ".markdown")
+}
+
+func stripKnownMarkdownExtension(target string) string {
+	lower := strings.ToLower(target)
+	if strings.HasSuffix(lower, ".md") {
+		return target[:len(target)-len(".md")]
+	}
+	if strings.HasSuffix(lower, ".markdown") {
+		return target[:len(target)-len(".markdown")]
+	}
+	return target
+}

--- a/internal/lint/link_target_rewrite_test.go
+++ b/internal/lint/link_target_rewrite_test.go
@@ -1,0 +1,112 @@
+package lint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeUpdatedLinkTarget_RelativeAcrossDirectories(t *testing.T) {
+	repoRoot := t.TempDir()
+	sourceFile := filepath.Join(repoRoot, "docs", "a", "source.md")
+	oldAbs := filepath.Join(repoRoot, "docs", "old", "target.md")
+	newAbs := filepath.Join(repoRoot, "docs", "new", "target.md")
+
+	writeFile(t, sourceFile, "# source")
+	writeFile(t, oldAbs, "# old")
+	writeFile(t, newAbs, "# new")
+
+	originalTarget := "../old/target.md#section"
+	updated, changed, err := computeUpdatedLinkTarget(sourceFile, originalTarget, oldAbs, newAbs)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "../new/target.md#section", updated)
+
+	resolved, err := resolveRelativePath(sourceFile, updated)
+	require.NoError(t, err)
+	require.Equal(t, newAbs, resolved)
+}
+
+func TestComputeUpdatedLinkTarget_SameDir_PreservesDotSlash(t *testing.T) {
+	repoRoot := t.TempDir()
+	sourceFile := filepath.Join(repoRoot, "docs", "a", "source.md")
+	oldAbs := filepath.Join(repoRoot, "docs", "a", "old.md")
+	newAbs := filepath.Join(repoRoot, "docs", "a", "new.md")
+
+	writeFile(t, sourceFile, "# source")
+	writeFile(t, oldAbs, "# old")
+	writeFile(t, newAbs, "# new")
+
+	updated, changed, err := computeUpdatedLinkTarget(sourceFile, "./old.md", oldAbs, newAbs)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "./new.md", updated)
+
+	resolved, err := resolveRelativePath(sourceFile, updated)
+	require.NoError(t, err)
+	require.Equal(t, newAbs, resolved)
+}
+
+func TestComputeUpdatedLinkTarget_SiteAbsolute_PreservesLeadingSlash(t *testing.T) {
+	repoRoot := t.TempDir()
+	sourceFile := filepath.Join(repoRoot, "content", "en", "guide", "source.md")
+	oldAbs := filepath.Join(repoRoot, "content", "en", "api", "old.md")
+	newAbs := filepath.Join(repoRoot, "content", "en", "api", "new.md")
+
+	writeFile(t, sourceFile, "# source")
+	writeFile(t, oldAbs, "# old")
+	writeFile(t, newAbs, "# new")
+
+	updated, changed, err := computeUpdatedLinkTarget(sourceFile, "/en/api/old.md", oldAbs, newAbs)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "/en/api/new.md", updated)
+
+	resolved, err := resolveRelativePath(sourceFile, updated)
+	require.NoError(t, err)
+	require.Equal(t, newAbs, resolved)
+}
+
+func TestComputeUpdatedLinkTarget_Extensionless_PreservesNoExtension(t *testing.T) {
+	repoRoot := t.TempDir()
+	sourceFile := filepath.Join(repoRoot, "content", "en", "guide", "source.md")
+	oldAbs := filepath.Join(repoRoot, "content", "en", "api", "old.md")
+	newAbs := filepath.Join(repoRoot, "content", "en", "api", "new.md")
+
+	writeFile(t, sourceFile, "# source")
+	writeFile(t, oldAbs, "# old")
+	writeFile(t, newAbs, "# new")
+
+	updated, changed, err := computeUpdatedLinkTarget(sourceFile, "/en/api/old", oldAbs, newAbs)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "/en/api/new", updated)
+
+	resolved, err := resolveRelativePath(sourceFile, updated)
+	require.NoError(t, err)
+	require.Equal(t, newAbs, resolved)
+}
+
+func TestComputeUpdatedLinkTarget_FragmentOnly_NoChange(t *testing.T) {
+	repoRoot := t.TempDir()
+	sourceFile := filepath.Join(repoRoot, "docs", "a", "source.md")
+	oldAbs := filepath.Join(repoRoot, "docs", "a", "old.md")
+	newAbs := filepath.Join(repoRoot, "docs", "a", "new.md")
+
+	writeFile(t, sourceFile, "# source")
+	writeFile(t, oldAbs, "# old")
+	writeFile(t, newAbs, "# new")
+
+	updated, changed, err := computeUpdatedLinkTarget(sourceFile, "#section", oldAbs, newAbs)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Equal(t, "#section", updated)
+}
+
+func writeFile(t *testing.T, absPath string, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(absPath), 0o750))
+	require.NoError(t, os.WriteFile(absPath, []byte(content), 0o600))
+}

--- a/internal/lint/rename_mapping.go
+++ b/internal/lint/rename_mapping.go
@@ -1,0 +1,116 @@
+package lint
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// RenameSource records where a rename mapping came from.
+// This is used to distinguish fixer-driven renames from Git-detected renames.
+//
+// Note: Today only RenameSourceFixer is produced; other values will be used by ADR-012.
+type RenameSource string
+
+const (
+	RenameSourceFixer          RenameSource = "fixer"
+	RenameSourceGitUncommitted RenameSource = "git-uncommitted"
+	RenameSourceGitHistory     RenameSource = "git-history"
+)
+
+// RenameMapping represents a single old->new mapping.
+// Paths must be absolute on disk.
+type RenameMapping struct {
+	OldAbs string
+	NewAbs string
+	Source RenameSource
+}
+
+// NormalizeRenameMappings validates, filters, de-duplicates, and sorts rename mappings.
+//
+// - Requires OldAbs/NewAbs to be absolute paths.
+// - If docsRoots is non-empty, keeps only mappings where both paths are within any docs root.
+// - Removes exact duplicates.
+// - Sorts deterministically by OldAbs, then NewAbs, then Source.
+func NormalizeRenameMappings(mappings []RenameMapping, docsRoots []string) ([]RenameMapping, error) {
+	if len(mappings) == 0 {
+		return nil, nil
+	}
+
+	absDocsRoots := make([]string, 0, len(docsRoots))
+	for _, root := range docsRoots {
+		if root == "" {
+			continue
+		}
+		if !filepath.IsAbs(root) {
+			return nil, fmt.Errorf("docs root must be an absolute path: %q", root)
+		}
+		absDocsRoots = append(absDocsRoots, filepath.Clean(root))
+	}
+
+	filtered := make([]RenameMapping, 0, len(mappings))
+	for _, m := range mappings {
+		if !filepath.IsAbs(m.OldAbs) || !filepath.IsAbs(m.NewAbs) {
+			return nil, fmt.Errorf("rename mapping paths must be absolute: old=%q new=%q", m.OldAbs, m.NewAbs)
+		}
+		m.OldAbs = filepath.Clean(m.OldAbs)
+		m.NewAbs = filepath.Clean(m.NewAbs)
+
+		if len(absDocsRoots) > 0 {
+			inScope := false
+			for _, root := range absDocsRoots {
+				if isWithinDir(m.OldAbs, root) && isWithinDir(m.NewAbs, root) {
+					inScope = true
+					break
+				}
+			}
+			if !inScope {
+				continue
+			}
+		}
+
+		filtered = append(filtered, m)
+	}
+
+	sort.Slice(filtered, func(i, j int) bool {
+		if filtered[i].OldAbs != filtered[j].OldAbs {
+			return filtered[i].OldAbs < filtered[j].OldAbs
+		}
+		if filtered[i].NewAbs != filtered[j].NewAbs {
+			return filtered[i].NewAbs < filtered[j].NewAbs
+		}
+		return string(filtered[i].Source) < string(filtered[j].Source)
+	})
+
+	deduped := make([]RenameMapping, 0, len(filtered))
+	seen := make(map[string]struct{}, len(filtered))
+	for _, m := range filtered {
+		key := strings.Join([]string{m.OldAbs, "\x00", m.NewAbs, "\x00", string(m.Source)}, "")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		deduped = append(deduped, m)
+	}
+
+	return deduped, nil
+}
+
+func isWithinDir(absPath, absDir string) bool {
+	absPath = filepath.Clean(absPath)
+	absDir = filepath.Clean(absDir)
+
+	rel, err := filepath.Rel(absDir, absPath)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	// If rel starts with "..", absPath is outside absDir.
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}

--- a/internal/lint/rename_mapping_test.go
+++ b/internal/lint/rename_mapping_test.go
@@ -1,0 +1,80 @@
+package lint
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeRenameMappings_RequiresAbsolutePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	docsRoot := filepath.Join(tmpDir, "docs")
+
+	mappings := []RenameMapping{{
+		OldAbs: "docs/old.md",
+		NewAbs: filepath.Join(docsRoot, "new.md"),
+		Source: RenameSourceFixer,
+	}}
+
+	_, err := NormalizeRenameMappings(mappings, []string{docsRoot})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute")
+}
+
+func TestNormalizeRenameMappings_FiltersToDocsRoots(t *testing.T) {
+	tmpDir := t.TempDir()
+	docsRoot := filepath.Join(tmpDir, "docs")
+	otherRoot := filepath.Join(tmpDir, "other")
+
+	mappings := []RenameMapping{
+		{
+			OldAbs: filepath.Join(docsRoot, "old.md"),
+			NewAbs: filepath.Join(docsRoot, "new.md"),
+			Source: RenameSourceFixer,
+		},
+		{
+			OldAbs: filepath.Join(otherRoot, "old.md"),
+			NewAbs: filepath.Join(otherRoot, "new.md"),
+			Source: RenameSourceFixer,
+		},
+		{
+			// Mixed roots should be dropped as out-of-scope.
+			OldAbs: filepath.Join(docsRoot, "a.md"),
+			NewAbs: filepath.Join(otherRoot, "a.md"),
+			Source: RenameSourceFixer,
+		},
+	}
+
+	got, err := NormalizeRenameMappings(mappings, []string{docsRoot})
+	require.NoError(t, err)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, filepath.Join(docsRoot, "old.md"), got[0].OldAbs)
+	assert.Equal(t, filepath.Join(docsRoot, "new.md"), got[0].NewAbs)
+}
+
+func TestNormalizeRenameMappings_DedupesAndSortsDeterministically(t *testing.T) {
+	tmpDir := t.TempDir()
+	docsRoot := filepath.Join(tmpDir, "docs")
+
+	aOld := filepath.Join(docsRoot, "a.md")
+	aNew := filepath.Join(docsRoot, "a-new.md")
+	bOld := filepath.Join(docsRoot, "b.md")
+	bNew := filepath.Join(docsRoot, "b-new.md")
+
+	mappings := []RenameMapping{
+		{OldAbs: bOld, NewAbs: bNew, Source: RenameSourceFixer},
+		{OldAbs: aOld, NewAbs: aNew, Source: RenameSourceFixer},
+		// Duplicate mapping should be removed.
+		{OldAbs: aOld, NewAbs: aNew, Source: RenameSourceFixer},
+	}
+
+	got, err := NormalizeRenameMappings(mappings, []string{docsRoot})
+	require.NoError(t, err)
+
+	require.Len(t, got, 2)
+	assert.Equal(t, aOld, got[0].OldAbs)
+	assert.Equal(t, bOld, got[1].OldAbs)
+}


### PR DESCRIPTION
### Summary
This PR extends `docbuilder lint --fix` to automatically repair broken Markdown links caused by file moves/renames, using Git rename detection (uncommitted + committed history) and a safety-first healing strategy. Healing is driven by the set of *actually broken links* and is skipped (with reporting) when the destination is ambiguous or unsafe to rewrite.

### Key changes
- **Broken-link-driven healing phase in the fixer pipeline**
  - Adds a dedicated “heal broken links from git renames” phase before fingerprint regeneration.
  - Only attempts rewrites for links detected as broken (keeps scope tight and performance proportional to actual issues).
- **Git rename detection (two sources)**
  - **Uncommitted renames**: detects staged + unstaged renames and surfaces them as rename mappings.
  - **Committed history renames**: detects renames since upstream (`upstream..HEAD`) with a bounded fallback strategy.
- **Correct, path-aware link target rewriting**
  - Computes updated link targets for moved files (relative and site-absolute forms), preserving fragments where applicable.
  - Improves link update correctness by preferring a “real path resolution + rewrite” approach over basename-only substitution when the old target truly resolves to the old file.
- **Safety + ambiguity handling**
  - Skips rewrites when multiple plausible destinations exist for a broken link (records “heal skipped” details in results).
  - Avoids rewriting targets outside the intended scope (e.g., external URLs / non-file link forms).
- **Rename-chain resolution (same-run destination renames)**
  - If Git indicates a move `old → subdir/File.md` and the fixer also normalizes/renames `subdir/File.md → subdir/file.md` in the same run, healing rewrites links directly to the **final** destination.
- **Collision behavior verified**
  - If a fixer rename would overwrite an existing file (e.g., case-only collision on case-sensitive FS), the rename is refused and an error is recorded so the user is warned; healing still behaves safely.

### Implementation notes
- Introduces a `RenameMapping` model and normalization utilities to unify rename inputs from different detectors.
- Adds `FixResult.HealSkipped` reporting and includes it in summaries so users can see what was intentionally *not* rewritten.

### Tests added
- Unit + workflow coverage for:
  - Healing from uncommitted git renames
  - Healing from history renames (since upstream)
  - Skipping ambiguous rename mappings (with structured reporting)
  - Healing to final destination when the destination is also renamed by the fixer in the same run
  - Rename collision regressions (case-only and history-induced collisions)

### Files changed (high level)
- Lint/fixer + healing:
  - `internal/lint/broken_link_healer.go`
  - `internal/lint/fixer.go`
  - `internal/lint/fixer_link_updates.go`
  - `internal/lint/fixer_result.go`
- Git rename detection:
  - `internal/lint/git_uncommitted_rename_detector.go`
  - `internal/lint/git_history_rename_detector.go`
- Link rewriting + mapping utilities:
  - `internal/lint/link_target_rewrite.go`
  - `internal/lint/rename_mapping.go`
- Tests:
  - `internal/lint/fixer_broken_link_heal_test.go`
  - `internal/lint/fixer_workflow_test.go`
  - `internal/lint/link_target_rewrite_test.go`
  - `internal/lint/git_*_rename_detector_test.go`
  - `internal/lint/rename_mapping_test.go`
  - `internal/lint/link_update_test.go`
- ADR docs:
  - `docs/adr/adr-012-autoheal-links-to-moved-files.md`
  - `docs/adr/adr-012-implementation-plan.md`

### How to verify
- Run unit tests: `go test ./...`
- Focused lint tests: `go test ./internal/lint -run Heal -v`
- Manual smoke test:
  1. Create a repo with `docs/a.md` linking to `docs/b.md`
  2. Rename/move `b.md` via `git mv`
  3. Run `docbuilder lint --fix`
  4. Confirm the link in `a.md` is rewritten (or explicitly skipped with a reported reason if ambiguous)

### Commit list (for reviewer navigation)
- `1df8f3d` test(lint): cover rename collision edge cases
- `6281a15` fix(lint): heal links to final renamed path
- `c25548c` docs(adr): mark ADR-012 work item 5 complete
- `6360aa5` feat(lint): detect committed renames since upstream
- `225d67a` feat(lint): heal broken links from git renames
- `a5f2b5d` docs(adr): mark ADR-012 steps 0-3 complete
- `8c76205` feat(lint): compute updated link targets for moved files
- `ac7a996` feat(lint): detect uncommitted git renames
- `c664cd1` refactor(lint): add rename mapping normalization
- `41ba5d7` test(lint): characterize rename and link update behavior
- `16c5006` docs(adr): expand ADR-012 and add implementation plan