### PR TITLE
fix(daemon): recheck filtered repos on webhook

### DIFF
--- a/internal/daemon/daemon_webhook_ignored_repo_test.go
+++ b/internal/daemon/daemon_webhook_ignored_repo_test.go
@@ -1,0 +1,291 @@
+package daemon
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"git.home.luguber.info/inful/docbuilder/internal/build/queue"
+	"git.home.luguber.info/inful/docbuilder/internal/config"
+	"git.home.luguber.info/inful/docbuilder/internal/daemon/events"
+	"git.home.luguber.info/inful/docbuilder/internal/forge"
+	"git.home.luguber.info/inful/docbuilder/internal/git"
+)
+
+type webhookProbeForgeClient struct {
+	repo                    forge.Repository
+	hasDocs                 bool
+	hasDocIgnore            bool
+	getRepositoryCalls      atomic.Int32
+	checkDocumentationCalls atomic.Int32
+}
+
+func (c *webhookProbeForgeClient) GetType() forge.Type { return forge.TypeForgejo }
+func (c *webhookProbeForgeClient) GetName() string     { return "forge-1" }
+
+func (c *webhookProbeForgeClient) ListOrganizations(context.Context) ([]*forge.Organization, error) {
+	return []*forge.Organization{}, nil
+}
+
+func (c *webhookProbeForgeClient) ListRepositories(context.Context, []string) ([]*forge.Repository, error) {
+	return []*forge.Repository{}, nil
+}
+
+func (c *webhookProbeForgeClient) GetRepository(_ context.Context, owner, repo string) (*forge.Repository, error) {
+	c.getRepositoryCalls.Add(1)
+
+	repoCopy := c.repo
+	return &repoCopy, nil
+}
+
+func (c *webhookProbeForgeClient) CheckDocumentation(_ context.Context, repo *forge.Repository) error {
+	c.checkDocumentationCalls.Add(1)
+	repo.HasDocs = c.hasDocs
+	repo.HasDocIgnore = c.hasDocIgnore
+	return nil
+}
+
+func (c *webhookProbeForgeClient) ValidateWebhook([]byte, string, string) bool { return true }
+func (c *webhookProbeForgeClient) ParseWebhookEvent([]byte, string) (*forge.WebhookEvent, error) {
+	return &forge.WebhookEvent{}, nil
+}
+
+func (c *webhookProbeForgeClient) RegisterWebhook(context.Context, *forge.Repository, string) error {
+	return nil
+}
+
+func (c *webhookProbeForgeClient) GetEditURL(*forge.Repository, string, string) string { return "" }
+
+func TestDaemon_TriggerWebhookBuild_FetchesPreviouslyFilteredRepoWhenDocsAppear(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	bus := events.NewBus()
+	defer bus.Close()
+
+	bq := queue.NewBuildQueue(10, 1, noOpBuilder{})
+	bq.Start(ctx)
+	defer bq.Stop(context.Background())
+
+	cfg := &config.Config{
+		Version: "2.0",
+		Daemon:  &config.DaemonConfig{Sync: config.SyncConfig{Schedule: "0 */4 * * *"}},
+		Filtering: &config.FilteringConfig{
+			RequiredPaths: []string{"docs"},
+		},
+		Forges: []*config.ForgeConfig{{
+			Name:    "forge-1",
+			Type:    config.ForgeForgejo,
+			BaseURL: "https://forgejo.example.com",
+		}},
+	}
+
+	forgeClient := &webhookProbeForgeClient{
+		repo: forge.Repository{
+			ID:            "2",
+			Name:          "new-docs",
+			FullName:      "org/new-docs",
+			CloneURL:      "https://forgejo.example.com/org/new-docs.git",
+			SSHURL:        "ssh://git@forgejo.example.com/org/new-docs.git",
+			DefaultBranch: "main",
+			Metadata:      map[string]string{"forge_name": "forge-1"},
+		},
+		hasDocs: true,
+	}
+
+	forgeManager := forge.NewForgeManager()
+	forgeManager.AddForge(cfg.Forges[0], forgeClient)
+
+	d := &Daemon{
+		config:           cfg,
+		stopChan:         make(chan struct{}),
+		orchestrationBus: bus,
+		buildQueue:       bq,
+		forgeManager:     forgeManager,
+		discovery:        forge.NewDiscoveryService(forgeManager, cfg.Filtering),
+		discoveryCache:   NewDiscoveryCache(),
+	}
+	d.status.Store(StatusRunning)
+
+	d.discoveryCache.Update(&forge.DiscoveryResult{
+		Repositories: []*forge.Repository{{
+			ID:            "1",
+			Name:          "existing-project",
+			FullName:      "org/existing-project",
+			CloneURL:      "https://forgejo.example.com/org/existing-project.git",
+			SSHURL:        "ssh://git@forgejo.example.com/org/existing-project.git",
+			DefaultBranch: "main",
+			Metadata:      map[string]string{"forge_name": "forge-1"},
+		}},
+		Filtered: []*forge.Repository{{
+			ID:            "2",
+			Name:          "new-docs",
+			FullName:      "org/new-docs",
+			CloneURL:      "https://forgejo.example.com/org/new-docs.git",
+			SSHURL:        "ssh://git@forgejo.example.com/org/new-docs.git",
+			DefaultBranch: "main",
+			HasDocs:       false,
+			Metadata:      map[string]string{"forge_name": "forge-1"},
+		}},
+	})
+
+	debouncer, err := NewBuildDebouncer(bus, BuildDebouncerConfig{
+		QuietWindow: 50 * time.Millisecond,
+		MaxDelay:    100 * time.Millisecond,
+		CheckBuildRunning: func() bool {
+			return len(bq.GetActiveJobs()) > 0
+		},
+		PollInterval: 5 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	d.buildDebouncer = debouncer
+
+	cache, err := git.NewRemoteHeadCache("")
+	require.NoError(t, err)
+	d.repoUpdater = NewRepoUpdater(bus, alwaysChangedRemoteHeadChecker{}, cache, d.currentReposForOrchestratedBuild)
+
+	go d.runBuildNowConsumer(ctx)
+	go d.runWebhookReceivedConsumer(ctx)
+	go d.repoUpdater.Run(ctx)
+	go func() { _ = debouncer.Run(ctx) }()
+
+	select {
+	case <-d.repoUpdater.Ready():
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for repo updater ready")
+	}
+
+	select {
+	case <-debouncer.Ready():
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out waiting for debouncer ready")
+	}
+
+	require.Eventually(t, func() bool {
+		return events.SubscriberCount[events.WebhookReceived](bus) > 0 &&
+			events.SubscriberCount[events.BuildNow](bus) > 0
+	}, 1*time.Second, 10*time.Millisecond)
+
+	jobID := d.TriggerWebhookBuild("forge-1", "org/new-docs", "main", []string{"docs/README.md"})
+	require.NotEmpty(t, jobID)
+
+	require.Eventually(t, func() bool {
+		job, ok := bq.JobSnapshot(jobID)
+		return ok && job != nil && job.Status == queue.BuildStatusCompleted
+	}, 5*time.Second, 10*time.Millisecond)
+
+	job, ok := bq.JobSnapshot(jobID)
+	require.True(t, ok)
+	require.NotNil(t, job)
+	require.NotNil(t, job.TypedMeta)
+	require.Len(t, job.TypedMeta.Repositories, 2)
+
+	var target *config.Repository
+	for i := range job.TypedMeta.Repositories {
+		repo := &job.TypedMeta.Repositories[i]
+		if repo.Name == "new-docs" {
+			target = repo
+			break
+		}
+	}
+	require.NotNil(t, target)
+	require.Equal(t, "main", target.Branch)
+	require.Equal(t, "https://forgejo.example.com/org/new-docs.git", target.URL)
+	require.EqualValues(t, 1, forgeClient.getRepositoryCalls.Load())
+	require.EqualValues(t, 1, forgeClient.checkDocumentationCalls.Load())
+}
+
+func TestDaemon_TriggerWebhookBuild_DoesNotReviveDocIgnoredRepo(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	bus := events.NewBus()
+	defer bus.Close()
+
+	cfg := &config.Config{
+		Version: "2.0",
+		Daemon:  &config.DaemonConfig{Sync: config.SyncConfig{Schedule: "0 */4 * * *"}},
+		Filtering: &config.FilteringConfig{
+			RequiredPaths: []string{"docs"},
+		},
+		Forges: []*config.ForgeConfig{{
+			Name:    "forge-1",
+			Type:    config.ForgeForgejo,
+			BaseURL: "https://forgejo.example.com",
+		}},
+	}
+
+	forgeClient := &webhookProbeForgeClient{
+		repo: forge.Repository{
+			ID:            "2",
+			Name:          "new-docs",
+			FullName:      "org/new-docs",
+			CloneURL:      "https://forgejo.example.com/org/new-docs.git",
+			SSHURL:        "ssh://git@forgejo.example.com/org/new-docs.git",
+			DefaultBranch: "main",
+			Metadata:      map[string]string{"forge_name": "forge-1"},
+		},
+		hasDocs:      true,
+		hasDocIgnore: true,
+	}
+
+	forgeManager := forge.NewForgeManager()
+	forgeManager.AddForge(cfg.Forges[0], forgeClient)
+
+	d := &Daemon{
+		config:           cfg,
+		stopChan:         make(chan struct{}),
+		orchestrationBus: bus,
+		forgeManager:     forgeManager,
+		discovery:        forge.NewDiscoveryService(forgeManager, cfg.Filtering),
+		discoveryCache:   NewDiscoveryCache(),
+	}
+	d.status.Store(StatusRunning)
+
+	d.discoveryCache.Update(&forge.DiscoveryResult{
+		Repositories: []*forge.Repository{{
+			ID:            "1",
+			Name:          "existing-project",
+			FullName:      "org/existing-project",
+			CloneURL:      "https://forgejo.example.com/org/existing-project.git",
+			SSHURL:        "ssh://git@forgejo.example.com/org/existing-project.git",
+			DefaultBranch: "main",
+			Metadata:      map[string]string{"forge_name": "forge-1"},
+		}},
+		Filtered: []*forge.Repository{{
+			ID:            "2",
+			Name:          "new-docs",
+			FullName:      "org/new-docs",
+			CloneURL:      "https://forgejo.example.com/org/new-docs.git",
+			SSHURL:        "ssh://git@forgejo.example.com/org/new-docs.git",
+			DefaultBranch: "main",
+			HasDocs:       false,
+			Metadata:      map[string]string{"forge_name": "forge-1"},
+		}},
+	})
+
+	repoUpdateCh, unsubRepoUpdate := events.Subscribe[events.RepoUpdateRequested](bus, 10)
+	defer unsubRepoUpdate()
+
+	go d.runWebhookReceivedConsumer(ctx)
+
+	require.Eventually(t, func() bool {
+		return events.SubscriberCount[events.WebhookReceived](bus) > 0
+	}, 1*time.Second, 10*time.Millisecond)
+
+	jobID := d.TriggerWebhookBuild("forge-1", "org/new-docs", "main", []string{"docs/README.md"})
+	require.NotEmpty(t, jobID)
+
+	select {
+	case <-repoUpdateCh:
+		t.Fatal("expected no RepoUpdateRequested for .docignore-protected repo")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	require.EqualValues(t, 1, forgeClient.getRepositoryCalls.Load())
+	require.EqualValues(t, 1, forgeClient.checkDocumentationCalls.Load())
+	require.Len(t, d.currentReposForOrchestratedBuild(), 1)
+}

--- a/internal/daemon/webhook_received_consumer.go
+++ b/internal/daemon/webhook_received_consumer.go
@@ -202,20 +202,21 @@ func (d *Daemon) upsertWebhookDiscoveredRepo(repo *forge.Repository) {
 		return
 	}
 
-	current, _ := d.discoveryCache.Get()
-	next := &forge.DiscoveryResult{
-		Timestamp: time.Now(),
-	}
-	if current != nil {
-		*next = *current
-		next.Repositories = append([]*forge.Repository(nil), current.Repositories...)
-		next.Filtered = append([]*forge.Repository(nil), current.Filtered...)
-	}
+	d.discoveryCache.Merge(func(current *forge.DiscoveryResult) *forge.DiscoveryResult {
+		next := &forge.DiscoveryResult{
+			Timestamp: time.Now(),
+		}
+		if current != nil {
+			*next = *current
+			next.Repositories = append([]*forge.Repository(nil), current.Repositories...)
+			next.Filtered = append([]*forge.Repository(nil), current.Filtered...)
+		}
 
-	repoCopy := *repo
-	next.Repositories = upsertWebhookRepoEntry(next.Repositories, &repoCopy)
-	next.Filtered = removeWebhookRepoEntry(next.Filtered, repo)
-	d.discoveryCache.Update(next)
+		repoCopy := *repo
+		next.Repositories = upsertWebhookRepoEntry(next.Repositories, &repoCopy)
+		next.Filtered = removeWebhookRepoEntry(next.Filtered, repo)
+		return next
+	})
 }
 
 func upsertWebhookRepoEntry(repos []*forge.Repository, target *forge.Repository) []*forge.Repository {

--- a/internal/daemon/webhook_received_consumer.go
+++ b/internal/daemon/webhook_received_consumer.go
@@ -9,6 +9,7 @@ import (
 
 	"git.home.luguber.info/inful/docbuilder/internal/config"
 	"git.home.luguber.info/inful/docbuilder/internal/daemon/events"
+	"git.home.luguber.info/inful/docbuilder/internal/forge"
 	"git.home.luguber.info/inful/docbuilder/internal/logfields"
 )
 
@@ -41,9 +42,6 @@ func (d *Daemon) handleWebhookReceived(ctx context.Context, evt events.WebhookRe
 	evtBranch := normalizeGitBranchRef(evt.Branch)
 
 	repos := d.currentReposForOrchestratedBuild()
-	if d.handleWebhookWithNoRepos(ctx, evt, evtBranch, repos) {
-		return
-	}
 
 	forgeHost := ""
 	if evt.ForgeName != "" && d.forgeManager != nil {
@@ -53,8 +51,14 @@ func (d *Daemon) handleWebhookReceived(ctx context.Context, evt events.WebhookRe
 	}
 
 	matchedRepoURL, matchedBranch, matchedDocsPaths := d.matchWebhookRepo(evt, evtBranch, forgeHost, repos)
+	if matchedRepoURL == "" {
+		matchedRepoURL, matchedBranch, matchedDocsPaths = d.resolveWebhookRepoFromForge(ctx, evt)
+	}
 
 	if matchedRepoURL == "" {
+		if d.handleWebhookWithNoRepos(ctx, evt, evtBranch, repos) {
+			return
+		}
 		slog.Warn("Webhook did not match any known repository",
 			logfields.JobID(evt.JobID),
 			slog.String("forge", evt.ForgeName),
@@ -106,6 +110,151 @@ func (d *Daemon) handleWebhookReceived(ctx context.Context, evt events.WebhookRe
 			slog.String("repo_url", matchedRepoURL),
 			logfields.Error(err))
 	}
+}
+
+func (d *Daemon) resolveWebhookRepoFromForge(ctx context.Context, evt events.WebhookReceived) (string, string, []string) {
+	if ctx == nil || d == nil || d.forgeManager == nil || d.discovery == nil {
+		return "", "", nil
+	}
+	if strings.TrimSpace(evt.ForgeName) == "" || strings.TrimSpace(evt.RepoFullName) == "" {
+		return "", "", nil
+	}
+	if !hasDocsRelevantChange(evt.ChangedFiles, nil) {
+		return "", "", nil
+	}
+
+	client := d.forgeManager.GetForge(evt.ForgeName)
+	if client == nil {
+		return "", "", nil
+	}
+
+	owner, repoName, ok := splitWebhookRepoFullName(evt.RepoFullName)
+	if !ok {
+		return "", "", nil
+	}
+
+	repo, err := client.GetRepository(ctx, owner, repoName)
+	if err != nil {
+		slog.Warn("Failed to fetch repository after unmatched webhook",
+			logfields.JobID(evt.JobID),
+			slog.String("forge", evt.ForgeName),
+			slog.String("repo", evt.RepoFullName),
+			logfields.Error(err))
+		return "", "", nil
+	}
+	if repo == nil {
+		return "", "", nil
+	}
+	if repo.Metadata == nil {
+		repo.Metadata = make(map[string]string)
+	}
+	if repo.Metadata["forge_name"] == "" {
+		repo.Metadata["forge_name"] = evt.ForgeName
+	}
+
+	if err := client.CheckDocumentation(ctx, repo); err != nil {
+		slog.Warn("Failed to check repository documentation after unmatched webhook",
+			logfields.JobID(evt.JobID),
+			slog.String("forge", evt.ForgeName),
+			slog.String("repo", evt.RepoFullName),
+			logfields.Error(err))
+		return "", "", nil
+	}
+
+	include, reason := d.discovery.ShouldIncludeRepository(repo)
+	if !include {
+		slog.Info("Webhook repo remains excluded after direct probe",
+			logfields.JobID(evt.JobID),
+			slog.String("forge", evt.ForgeName),
+			slog.String("repo", evt.RepoFullName),
+			slog.String("reason", reason))
+		return "", "", nil
+	}
+
+	d.upsertWebhookDiscoveredRepo(repo)
+
+	converted := d.discovery.ConvertToConfigRepositories([]*forge.Repository{repo}, d.forgeManager)
+	if len(converted) == 0 {
+		return "", normalizeGitBranchRef(repo.DefaultBranch), []string{"docs"}
+	}
+
+	cfgRepo := converted[0]
+	docsPaths := cfgRepo.Paths
+	if len(docsPaths) == 0 {
+		docsPaths = []string{"docs"}
+	}
+
+	slog.Info("Webhook matched repository after direct probe",
+		logfields.JobID(evt.JobID),
+		slog.String("forge", evt.ForgeName),
+		slog.String("repo", evt.RepoFullName),
+		slog.String("repo_url", cfgRepo.URL))
+
+	return cfgRepo.URL, normalizeGitBranchRef(cfgRepo.Branch), docsPaths
+}
+
+func (d *Daemon) upsertWebhookDiscoveredRepo(repo *forge.Repository) {
+	if d == nil || d.discoveryCache == nil || repo == nil {
+		return
+	}
+
+	current, _ := d.discoveryCache.Get()
+	next := &forge.DiscoveryResult{
+		Timestamp: time.Now(),
+	}
+	if current != nil {
+		*next = *current
+		next.Repositories = append([]*forge.Repository(nil), current.Repositories...)
+		next.Filtered = append([]*forge.Repository(nil), current.Filtered...)
+	}
+
+	repoCopy := *repo
+	next.Repositories = upsertWebhookRepoEntry(next.Repositories, &repoCopy)
+	next.Filtered = removeWebhookRepoEntry(next.Filtered, repo)
+	d.discoveryCache.Update(next)
+}
+
+func upsertWebhookRepoEntry(repos []*forge.Repository, target *forge.Repository) []*forge.Repository {
+	for i := range repos {
+		if sameWebhookRepo(repos[i], target) {
+			repos[i] = target
+			return repos
+		}
+	}
+	return append(repos, target)
+}
+
+func removeWebhookRepoEntry(repos []*forge.Repository, target *forge.Repository) []*forge.Repository {
+	filtered := repos[:0]
+	for _, repo := range repos {
+		if sameWebhookRepo(repo, target) {
+			continue
+		}
+		filtered = append(filtered, repo)
+	}
+	return filtered
+}
+
+func sameWebhookRepo(left, right *forge.Repository) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	if left.CloneURL != "" && right.CloneURL != "" && left.CloneURL == right.CloneURL {
+		return true
+	}
+	return left.FullName != "" && left.FullName == right.FullName
+}
+
+func splitWebhookRepoFullName(fullName string) (string, string, bool) {
+	fullName = strings.TrimSpace(fullName)
+	if fullName == "" {
+		return "", "", false
+	}
+	lastSlash := strings.LastIndex(fullName, "/")
+	if lastSlash <= 0 || lastSlash == len(fullName)-1 {
+		return "", "", false
+	}
+	return fullName[:lastSlash], fullName[lastSlash+1:], true
 }
 
 func (d *Daemon) handleWebhookWithNoRepos(ctx context.Context, evt events.WebhookReceived, evtBranch string, repos []config.Repository) bool {

--- a/internal/daemon/webhook_received_consumer.go
+++ b/internal/daemon/webhook_received_consumer.go
@@ -119,7 +119,11 @@ func (d *Daemon) resolveWebhookRepoFromForge(ctx context.Context, evt events.Web
 	if strings.TrimSpace(evt.ForgeName) == "" || strings.TrimSpace(evt.RepoFullName) == "" {
 		return "", "", nil
 	}
-	if !hasDocsRelevantChange(evt.ChangedFiles, nil) {
+	relevantPaths := []string{"docs"}
+	if d.config != nil && d.config.Filtering != nil && len(d.config.Filtering.RequiredPaths) > 0 {
+		relevantPaths = d.config.Filtering.RequiredPaths
+	}
+	if !hasDocsRelevantChange(evt.ChangedFiles, relevantPaths) {
 		return "", "", nil
 	}
 

--- a/internal/forge/discovery.go
+++ b/internal/forge/discovery.go
@@ -296,6 +296,11 @@ func (ds *DiscoveryService) discoverForge(ctx context.Context, client Client) ([
 // shouldIncludeRepository determines if a repository should be included based on filtering config.
 
 func (ds *DiscoveryService) filterDecision(repo *Repository) repoFilterDecision {
+	filtering := ds.filtering
+	if filtering == nil {
+		filtering = &config.FilteringConfig{RequiredPaths: []string{"docs"}}
+	}
+
 	// Skip archived repositories
 	if repo.Archived {
 		return repoFilterDecision{include: false, reason: archivedToken}
@@ -307,14 +312,14 @@ func (ds *DiscoveryService) filterDecision(repo *Repository) repoFilterDecision 
 	}
 
 	// Check if repository has required paths (e.g., docs folder)
-	if !repo.HasDocs && len(ds.filtering.RequiredPaths) > 0 {
+	if !repo.HasDocs && len(filtering.RequiredPaths) > 0 {
 		return repoFilterDecision{include: false, reason: "missing_required_paths"}
 	}
 
 	// Check include patterns
-	if len(ds.filtering.IncludePatterns) > 0 {
+	if len(filtering.IncludePatterns) > 0 {
 		included := false
-		for _, pattern := range ds.filtering.IncludePatterns {
+		for _, pattern := range filtering.IncludePatterns {
 			if matchesPattern(repo.Name, pattern) || matchesPattern(repo.FullName, pattern) {
 				included = true
 				break
@@ -326,13 +331,20 @@ func (ds *DiscoveryService) filterDecision(repo *Repository) repoFilterDecision 
 	}
 
 	// Check exclude patterns
-	for _, pattern := range ds.filtering.ExcludePatterns {
+	for _, pattern := range filtering.ExcludePatterns {
 		if matchesPattern(repo.Name, pattern) || matchesPattern(repo.FullName, pattern) {
 			return repoFilterDecision{include: false, reason: "exclude_patterns_match", detail: pattern}
 		}
 	}
 
 	return repoFilterDecision{include: true, reason: "included"}
+}
+
+// ShouldIncludeRepository applies the same inclusion logic used during full
+// discovery so callers can consistently evaluate a single repository.
+func (ds *DiscoveryService) ShouldIncludeRepository(repo *Repository) (bool, string) {
+	decision := ds.filterDecision(repo)
+	return decision.include, decision.reason
 }
 
 // matchesPattern checks if a string matches a simple glob pattern

--- a/internal/forge/discoveryrunner/cache.go
+++ b/internal/forge/discoveryrunner/cache.go
@@ -28,6 +28,26 @@ func (c *Cache) Update(result *forge.DiscoveryResult) {
 	c.err = nil
 }
 
+// Merge performs an atomic read-modify-write of the cached result.
+// If mergeFn or its return value is nil, the cache is left unchanged.
+// Successful merges clear any previous cached error.
+func (c *Cache) Merge(mergeFn func(current *forge.DiscoveryResult) *forge.DiscoveryResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if mergeFn == nil {
+		return
+	}
+
+	next := mergeFn(c.result)
+	if next == nil {
+		return
+	}
+
+	c.result = next
+	c.err = nil
+}
+
 // SetError stores a discovery error, preserving the previous result (if any).
 func (c *Cache) SetError(err error) {
 	c.mu.Lock()

--- a/internal/forge/discoveryrunner/cache_test.go
+++ b/internal/forge/discoveryrunner/cache_test.go
@@ -33,6 +33,47 @@ func TestCache_UpdateThenSetErrorPreservesResult(t *testing.T) {
 	require.Equal(t, someErr, err)
 }
 
+func TestCache_MergeUpdatesResultAndClearsError(t *testing.T) {
+	c := NewCache()
+
+	initial := &forge.DiscoveryResult{Repositories: []*forge.Repository{{CloneURL: "https://example.com/one.git"}}}
+	c.Update(initial)
+	c.SetError(forgeError("stale"))
+
+	c.Merge(func(current *forge.DiscoveryResult) *forge.DiscoveryResult {
+		require.Same(t, initial, current)
+		next := &forge.DiscoveryResult{}
+		*next = *current
+		next.Repositories = append([]*forge.Repository(nil), current.Repositories...)
+		next.Repositories = append(next.Repositories, &forge.Repository{CloneURL: "https://example.com/two.git"})
+		return next
+	})
+
+	res, err := c.Get()
+	require.NoError(t, err)
+	require.Len(t, res.Repositories, 2)
+	require.Equal(t, "https://example.com/one.git", res.Repositories[0].CloneURL)
+	require.Equal(t, "https://example.com/two.git", res.Repositories[1].CloneURL)
+}
+
+func TestCache_MergeNilResultIsNoOp(t *testing.T) {
+	c := NewCache()
+
+	initial := &forge.DiscoveryResult{Repositories: []*forge.Repository{{CloneURL: "https://example.com/one.git"}}}
+	c.Update(initial)
+	errBefore := forgeError("boom")
+	c.SetError(errBefore)
+
+	c.Merge(func(current *forge.DiscoveryResult) *forge.DiscoveryResult {
+		require.Same(t, initial, current)
+		return nil
+	})
+
+	res, err := c.Get()
+	require.Equal(t, errBefore, err)
+	require.Same(t, initial, res)
+}
+
 type forgeError string
 
 func (e forgeError) Error() string { return string(e) }


### PR DESCRIPTION
## Problem
Webhook-triggered builds in forge/discovery mode could miss repositories that were previously filtered out (for example, repos with no docs at discovery time).  
If docs were added later, an unmatched webhook for that repo would not reliably include it in the next build.

## Solution
This PR adds a direct re-probe path for unmatched webhook repositories when the webhook contains docs-relevant changes.

- When normal webhook-to-repo matching fails, the daemon now:
  - fetches the repository directly from the forge,
  - re-runs documentation checks,
  - applies the same inclusion filters used by discovery.
- If the repo is now eligible, it is:
  - moved into the active discovery set,
  - removed from filtered cache entries,
  - included in the next orchestrated build via a repo update request.
- `.docignore` behavior is preserved: protected repos remain excluded.

## Implementation Details
- Added unmatched webhook fallback resolution logic in the daemon webhook consumer.
- Added a reusable single-repo inclusion method in discovery so webhook re-probes use identical filter semantics as full discovery.
- Added cache upsert/reconciliation helpers for revived repositories.

## Testing
Added targeted tests to validate both positive and negative paths:

1. `TestDaemon_TriggerWebhookBuild_FetchesPreviouslyFilteredRepoWhenDocsAppear`
   - Verifies a previously filtered repo is re-probed, accepted, and included in build metadata.
2. `TestDaemon_TriggerWebhookBuild_DoesNotReviveDocIgnoredRepo`
   - Verifies `.docignore` repos remain excluded and do not trigger repo update requests.

Executed:
- `go test ./internal/daemon ./internal/forge`

## Risk / Impact
- Low to moderate.
- Change is scoped to unmatched webhook handling and gated by docs-relevant file changes.
- Existing branch filtering and docs-path relevance checks remain in place.
- Main behavioral change is intentional: previously filtered repos can now be revived when they become docs-eligible.