### PR TITLE
fix(hugo): preserve $...$ inline math through Goldmark passthrough

### DIFF
--- a/docs/how-to/use-relearn-theme.md
+++ b/docs/how-to/use-relearn-theme.md
@@ -275,6 +275,29 @@ DocBuilder automatically configures these defaults for Relearn:
 
 All defaults can be overridden in your configuration's `hugo.params` section.
 
+## Math Support
+
+Relearn renders mathematical notation through MathJax. DocBuilder wires up the standard delimiter pairs so the following forms all work out of the box:
+
+| Form | Type | Example |
+|------|------|---------|
+| `$x + y$` | inline | The sum $x + y$ is positive. |
+| `\(x + y\)` | inline | The sum \(x + y\) is positive. |
+| `$$x + y$$` | display (block) | $$x + y$$ |
+| `\[x + y\]` | display (block) | \[x + y\] |
+
+### Escaping literal `$` characters
+
+The `$...$` form is recognised as math whenever a paired `$` is found, so prose that contains a `$` character (currency, shell variables, etc.) will be misread as math. Escape a literal `$` with a backslash when it is **not** meant to start a math span:
+
+```markdown
+It costs \$5 and \$10.
+
+Use \$HOME or \$TMPDIR for paths.
+```
+
+If you cannot escape at the source (for example, the `$` appears inside a code-incompatible position), wrap the text in inline code with backticks (`` `$HOME` ``).
+
 ## Hugo Module Configuration
 
 DocBuilder uses Hugo Modules to automatically install Relearn. The theme is configured as:

--- a/docs/how-to/use-relearn-theme.md
+++ b/docs/how-to/use-relearn-theme.md
@@ -5,8 +5,8 @@ categories:
   - how-to
 date: 2025-12-15T00:00:00Z
 description: Relearn theme overview
-fingerprint: cad2b47a3afbbaf3e8f319d590ab1cf4d438535b3359485a2f8ca82a61db435e
-lastmod: "2026-01-22"
+fingerprint: 39f4157cdb927c0f651edabb9972670c6f58507b3f9bc8ec6d8e6e5f77d4ecaf
+lastmod: "2026-06-12"
 tags:
   - themes
   - relearn

--- a/internal/hugo/models/config.go
+++ b/internal/hugo/models/config.go
@@ -89,7 +89,7 @@ func (rc *RootConfig) EnableMathPassthrough() {
 	ext["passthrough"] = map[string]any{
 		"delimiters": map[string]any{
 			"block":  [][]string{{"\\[", "\\]"}, {"$$", "$$"}},
-			"inline": [][]string{{"\\(", "\\)"}},
+			"inline": [][]string{{"\\(", "\\)"}, {"$", "$"}},
 		},
 		"enable": true,
 	}

--- a/internal/hugo/testdata/hugo_config/relearn_custom_taxonomies.yaml
+++ b/internal/hugo/testdata/hugo_config/relearn_custom_taxonomies.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/internal/hugo/testdata/hugo_config/relearn_default_taxonomies.yaml
+++ b/internal/hugo/testdata/hugo_config/relearn_default_taxonomies.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/conflicting-paths/hugo-config.golden.yaml
+++ b/test/testdata/golden/conflicting-paths/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/cross-repo-links/hugo-config.golden.yaml
+++ b/test/testdata/golden/cross-repo-links/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/daemon-public-filter/hugo-config.golden.yaml
+++ b/test/testdata/golden/daemon-public-filter/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/deep-nesting/hugo-config.golden.yaml
+++ b/test/testdata/golden/deep-nesting/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/frontmatter-injection/hugo-config.golden.yaml
+++ b/test/testdata/golden/frontmatter-injection/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/image-paths/hugo-config.golden.yaml
+++ b/test/testdata/golden/image-paths/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/malformed-frontmatter/hugo-config.golden.yaml
+++ b/test/testdata/golden/malformed-frontmatter/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/menu-generation/hugo-config.golden.yaml
+++ b/test/testdata/golden/menu-generation/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/only-readme/hugo-config.golden.yaml
+++ b/test/testdata/golden/only-readme/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/section-indexes/hugo-config.golden.yaml
+++ b/test/testdata/golden/section-indexes/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/sidebar-group-by-multi-value/hugo-config.golden.yaml
+++ b/test/testdata/golden/sidebar-group-by-multi-value/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/sidebar-group-by-sibling-category/hugo-config.golden.yaml
+++ b/test/testdata/golden/sidebar-group-by-sibling-category/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/sidebar-group-by/hugo-config.golden.yaml
+++ b/test/testdata/golden/sidebar-group-by/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/special-chars/hugo-config.golden.yaml
+++ b/test/testdata/golden/special-chars/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/two-repos/hugo-config.golden.yaml
+++ b/test/testdata/golden/two-repos/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/uid-permalink-ref/hugo-config.golden.yaml
+++ b/test/testdata/golden/uid-permalink-ref/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:

--- a/test/testdata/golden/unicode-names/hugo-config.golden.yaml
+++ b/test/testdata/golden/unicode-names/hugo-config.golden.yaml
@@ -19,6 +19,8 @@ markup:
                     inline:
                         - - \(
                           - \)
+                        - - $
+                          - $
                 enable: true
         parser:
             attribute:


### PR DESCRIPTION
Closes #62

## Problem

Inline math written as `$x+x$` was not being rendered by MathJax in
the Relearn theme, while display math `$$x+x$$` rendered fine.

## Root cause

The Goldmark `passthrough` extension is what preserves math delimiters
through markdown parsing and hands them to MathJax. In
`internal/hugo/models/config.go`, `EnableMathPassthrough` configured
only `\\(...\\)` as the inline delimiter set. `$...$` was not in
the list, so Goldmark treated it as ordinary text and stripped/rewrote
it during rendering.

## Fix

Add `{"$", "$"}` to the inline delimiters in
`EnableMathPassthrough`, alongside the existing `\\(...\\)` pair.
Both conventional inline-math forms now pass through to MathJax.
Display math delimiters (`$$...$$`, `\\[...\\]`) are unchanged
and were already working.

## Trade-off: escaping literal `$`

With `$...$` recognised as math, any paired `$` characters in
prose will be treated as a math span. This is the same convention
KaTeX, MathJax and Pandoc use. Content with currency, shell variables,
or any other literal `$` must escape with `\\$. For example:

```markdown
It costs \$5 and \$10.
Use \$HOME or \$TMPDIR for paths.
```

This is documented in `docs/how-to/use-relearn-theme.md` (new
"Math Support" section).

## Verification

- `go test ./...` — all packages pass
- `golangci-lint run ./...` — 0 issues
- `go vet ./internal/hugo/...` — clean
- `go build ./...` — clean
- 18 golden test fixtures + 2 hugo_config testdata fixtures updated to
  reflect the new inline delimiter pair